### PR TITLE
Resolved issue #19

### DIFF
--- a/src/classes/collections/ContainerCollection.php
+++ b/src/classes/collections/ContainerCollection.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Darling\PHPJsonStorageUtilities\classes\collections;
+
+use \Darling\PHPJsonStorageUtilities\interfaces\collections\ContainerCollection as ContainerCollectionInterface;
+use \Darling\PHPJsonStorageUtilities\interfaces\named\identifiers\Container;
+
+class ContainerCollection implements ContainerCollectionInterface
+{
+
+    /**
+     * @var array<int, Container> $containers
+     */
+    private array $containers;
+
+    public function __construct(
+        Container ...$containers
+    ) {
+        foreach($containers as $container) {
+            $this->containers[] = $container;
+        }
+    }
+
+    public function collection(): array
+    {
+        return $this->containers;
+    }
+
+}
+

--- a/src/classes/collections/IdCollection.php
+++ b/src/classes/collections/IdCollection.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Darling\PHPJsonStorageUtilities\classes\collections;
+
+use \Darling\PHPJsonStorageUtilities\interfaces\collections\IdCollection as IdCollectionInterface;
+use \Darling\PHPTextTypes\interfaces\strings\Id;
+
+class IdCollection implements IdCollectionInterface
+{
+
+
+    /**
+     * @var array<int, Id> $ids
+     */
+    private array $ids;
+
+    public function __construct(
+        Id ...$ids
+    ) {
+        foreach($ids as $id) {
+            $this->ids[] = $id;
+        }
+    }
+
+    public function collection(): array
+    {
+        return $this->ids;
+    }
+
+}
+

--- a/src/classes/collections/JsonFilePathCollection.php
+++ b/src/classes/collections/JsonFilePathCollection.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Darling\PHPJsonStorageUtilities\classes\collections;
+
+use \Darling\PHPJsonStorageUtilities\interfaces\collections\JsonFilePathCollection as JsonFilePathCollectionInterface;
+use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\paths\JsonFilePath;
+
+class JsonFilePathCollection implements JsonFilePathCollectionInterface
+{
+
+
+    /**
+     * @var array<int, JsonFilePath> $jsonFilePaths
+     */
+    private array $jsonFilePaths;
+
+    public function __construct(
+        JsonFilePath ...$jsonFilePaths
+    ) {
+        foreach($jsonFilePaths as $jsonFilePath) {
+            $this->jsonFilePaths[] = $jsonFilePath;
+        }
+    }
+
+    public function collection(): array
+    {
+        return $this->jsonFilePaths;
+    }
+
+}
+

--- a/src/classes/collections/JsonStorageDirectoryPathCollection.php
+++ b/src/classes/collections/JsonStorageDirectoryPathCollection.php
@@ -2,8 +2,8 @@
 
 namespace Darling\PHPJsonStorageUtilities\classes\collections;
 
-use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\paths\JsonStorageDirectoryPath;
 use \Darling\PHPJsonStorageUtilities\interfaces\collections\JsonStorageDirectoryPathCollection as JsonStorageDirectoryPathCollectionInterface;
+use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\paths\JsonStorageDirectoryPath;
 
 class JsonStorageDirectoryPathCollection implements JsonStorageDirectoryPathCollectionInterface
 {

--- a/src/classes/collections/JsonStorageDirectoryPathCollection.php
+++ b/src/classes/collections/JsonStorageDirectoryPathCollection.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Darling\PHPJsonStorageUtilities\classes\collections;
+
+use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\paths\JsonStorageDirectoryPath;
+use \Darling\PHPJsonStorageUtilities\interfaces\collections\JsonStorageDirectoryPathCollection as JsonStorageDirectoryPathCollectionInterface;
+
+class JsonStorageDirectoryPathCollection implements JsonStorageDirectoryPathCollectionInterface
+{
+
+
+    /**
+     * @var array<int, JsonStorageDirectoryPath> $jsonStorageDirectoryPaths
+     */
+    private array $jsonStorageDirectoryPaths;
+
+    public function __construct(
+        JsonStorageDirectoryPath ...$jsonStorageDirectoryPaths
+    ) {
+        foreach($jsonStorageDirectoryPaths as $jsonStorageDirectoryPath) {
+            $this->jsonStorageDirectoryPaths[] = $jsonStorageDirectoryPath;
+        }
+    }
+
+    public function collection(): array
+    {
+        return $this->jsonStorageDirectoryPaths;
+    }
+
+}
+

--- a/src/classes/collections/LocationCollection.php
+++ b/src/classes/collections/LocationCollection.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Darling\PHPJsonStorageUtilities\classes\collections;
+
+use \Darling\PHPJsonStorageUtilities\interfaces\collections\LocationCollection as LocationCollectionInterface;
+use \Darling\PHPJsonStorageUtilities\interfaces\named\identifiers\Location;
+
+class LocationCollection implements LocationCollectionInterface
+{
+
+
+    /**
+     * @var array<int, Location> $locations
+     */
+    private array $locations;
+
+    public function __construct(
+        Location ...$locations
+    ) {
+        foreach($locations as $location) {
+            $this->locations[] = $location;
+        }
+    }
+
+    public function collection(): array
+    {
+        return $this->locations;
+    }
+
+}
+

--- a/src/classes/collections/NameCollection.php
+++ b/src/classes/collections/NameCollection.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Darling\PHPJsonStorageUtilities\classes\collections;
+
+use \Darling\PHPJsonStorageUtilities\interfaces\collections\NameCollection as NameCollectionInterface;
+use \Darling\PHPTextTypes\classes\strings\Name;
+
+class NameCollection implements NameCollectionInterface
+{
+
+    /**
+     * @var array<int, Name> $names
+     */
+    private array $names;
+
+    public function __construct(
+        Name ...$names
+    ) {
+        foreach($names as $name) {
+            $this->names[] = $name;
+        }
+    }
+
+    public function collection(): array
+    {
+        return $this->names;
+    }
+
+}
+

--- a/src/classes/collections/OwnerCollection.php
+++ b/src/classes/collections/OwnerCollection.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Darling\PHPJsonStorageUtilities\classes\collections;
+
+use \Darling\PHPJsonStorageUtilities\interfaces\collections\OwnerCollection as OwnerCollectionInterface;
+use \Darling\PHPJsonStorageUtilities\interfaces\named\identifiers\Owner;
+
+class OwnerCollection implements OwnerCollectionInterface
+{
+
+
+    /**
+     * @var array<int, Owner> $owners
+     */
+    private array $owners;
+
+    public function __construct(
+        Owner ...$owners
+    ) {
+        foreach($owners as $owner) {
+            $this->owners[] = $owner;
+        }
+    }
+
+    public function collection(): array
+    {
+        return $this->owners;
+    }
+
+}
+

--- a/src/classes/filesystem/storage/queries/JsonStorageQuery.php
+++ b/src/classes/filesystem/storage/queries/JsonStorageQuery.php
@@ -3,6 +3,7 @@
 namespace Darling\PHPJsonStorageUtilities\classes\filesystem\storage\queries;
 
 use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\paths\JsonStorageDirectoryPath;
+use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\paths\JsonFilePath;
 use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\storage\queries\JsonStorageQuery as JsonStorageQueryInterface;
 
 class JsonStorageQuery implements JsonStorageQueryInterface
@@ -11,17 +12,23 @@ class JsonStorageQuery implements JsonStorageQueryInterface
     /**
      * Instantiate a new JsonStorageQuery instance.
      *
-     * @param array<int, JsonStorageDirectoryPath> $jsonStorageDirectoryPaths
+     * @param array<int, JsonStorageDirectoryPath>|null $jsonStorageDirectoryPaths
+     * @param array<int, JsonFilePath>|null $jsonFilePaths
      *
      */
     public function __construct(
-        private readonly array $jsonStorageDirectoryPaths,
+        private readonly array|null $jsonStorageDirectoryPaths = null,
+        private readonly array|null $jsonFilePaths = null,
     ) { }
 
     public function jsonStorageDirectoryPaths(): array
     {
-        return $this->jsonStorageDirectoryPaths;
+        return $this->jsonStorageDirectoryPaths ?? [];
     }
 
+    public function jsonFilePaths(): array
+    {
+        return $this->jsonFilePaths ?? [];
+    }
 }
 

--- a/src/classes/filesystem/storage/queries/JsonStorageQuery.php
+++ b/src/classes/filesystem/storage/queries/JsonStorageQuery.php
@@ -4,6 +4,7 @@ namespace Darling\PHPJsonStorageUtilities\classes\filesystem\storage\queries;
 
 use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\paths\JsonStorageDirectoryPath;
 use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\paths\JsonFilePath;
+use \Darling\PHPJsonStorageUtilities\interfaces\named\identifiers\Location;
 use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\storage\queries\JsonStorageQuery as JsonStorageQueryInterface;
 
 class JsonStorageQuery implements JsonStorageQueryInterface
@@ -14,11 +15,13 @@ class JsonStorageQuery implements JsonStorageQueryInterface
      *
      * @param array<int, JsonStorageDirectoryPath>|null $jsonStorageDirectoryPaths
      * @param array<int, JsonFilePath>|null $jsonFilePaths
+     * @param array<int, Location>|null $locations
      *
      */
     public function __construct(
         private readonly array|null $jsonStorageDirectoryPaths = null,
         private readonly array|null $jsonFilePaths = null,
+        private readonly array|null $locations = null,
     ) { }
 
     public function jsonStorageDirectoryPaths(): array
@@ -29,6 +32,11 @@ class JsonStorageQuery implements JsonStorageQueryInterface
     public function jsonFilePaths(): array
     {
         return $this->jsonFilePaths ?? [];
+    }
+
+    public function locations(): array
+    {
+        return $this->locations ?? [];
     }
 }
 

--- a/src/classes/filesystem/storage/queries/JsonStorageQuery.php
+++ b/src/classes/filesystem/storage/queries/JsonStorageQuery.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Darling\PHPJsonStorageUtilities\classes\filesystem\storage\queries;
+
+use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\storage\queries\JsonStorageQuery as JsonStorageQueryInterface;
+use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\paths\JsonStorageDirectoryPath;
+
+class JsonStorageQuery implements JsonStorageQueryInterface
+{
+
+    /**
+     * Instantiate a new JsonStorageQuery instance.
+     *
+     * @param array<int, JsonStorageDirectoryPath> $jsonStorageDirectoryPaths
+     *
+     */
+    public function __construct(
+        private readonly array $jsonStorageDirectoryPaths,
+    ) { }
+
+    public function jsonStorageDirectoryPaths(): array
+    {
+        return $this->jsonStorageDirectoryPaths;
+    }
+
+}
+

--- a/src/classes/filesystem/storage/queries/JsonStorageQuery.php
+++ b/src/classes/filesystem/storage/queries/JsonStorageQuery.php
@@ -4,6 +4,7 @@ namespace Darling\PHPJsonStorageUtilities\classes\filesystem\storage\queries;
 
 use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\paths\JsonStorageDirectoryPath;
 use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\paths\JsonFilePath;
+use \Darling\PHPJsonStorageUtilities\classes\named\identifiers\Owner;
 use \Darling\PHPJsonStorageUtilities\interfaces\named\identifiers\Location;
 use \Darling\PHPJsonStorageUtilities\interfaces\named\identifiers\Container;
 use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\storage\queries\JsonStorageQuery as JsonStorageQueryInterface;
@@ -18,6 +19,7 @@ class JsonStorageQuery implements JsonStorageQueryInterface
      * @param array<int, JsonFilePath>|null $jsonFilePaths
      * @param array<int, Location>|null $locations
      * @param array<int, Container>|null $containers
+     * @param array<int, Owner>|null $owners
      *
      */
     public function __construct(
@@ -25,6 +27,7 @@ class JsonStorageQuery implements JsonStorageQueryInterface
         private array|null $jsonFilePaths = null,
         private array|null $locations = null,
         private array|null $containers = null,
+        private array|null $owners = null,
     ) { }
 
     public function jsonStorageDirectoryPaths(): array
@@ -46,5 +49,11 @@ class JsonStorageQuery implements JsonStorageQueryInterface
     {
         return $this->containers ?? [];
     }
+
+    public function owners(): array
+    {
+        return $this->owners ?? [];
+    }
+
 }
 

--- a/src/classes/filesystem/storage/queries/JsonStorageQuery.php
+++ b/src/classes/filesystem/storage/queries/JsonStorageQuery.php
@@ -5,6 +5,7 @@ namespace Darling\PHPJsonStorageUtilities\classes\filesystem\storage\queries;
 use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\paths\JsonStorageDirectoryPath;
 use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\paths\JsonFilePath;
 use \Darling\PHPJsonStorageUtilities\interfaces\named\identifiers\Location;
+use \Darling\PHPJsonStorageUtilities\interfaces\named\identifiers\Container;
 use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\storage\queries\JsonStorageQuery as JsonStorageQueryInterface;
 
 class JsonStorageQuery implements JsonStorageQueryInterface
@@ -16,12 +17,14 @@ class JsonStorageQuery implements JsonStorageQueryInterface
      * @param array<int, JsonStorageDirectoryPath>|null $jsonStorageDirectoryPaths
      * @param array<int, JsonFilePath>|null $jsonFilePaths
      * @param array<int, Location>|null $locations
+     * @param array<int, Container>|null $containers
      *
      */
     public function __construct(
-        private readonly array|null $jsonStorageDirectoryPaths = null,
-        private readonly array|null $jsonFilePaths = null,
-        private readonly array|null $locations = null,
+        private array|null $jsonStorageDirectoryPaths = null,
+        private array|null $jsonFilePaths = null,
+        private array|null $locations = null,
+        private array|null $containers = null,
     ) { }
 
     public function jsonStorageDirectoryPaths(): array
@@ -37,6 +40,11 @@ class JsonStorageQuery implements JsonStorageQueryInterface
     public function locations(): array
     {
         return $this->locations ?? [];
+    }
+
+    public function containers(): array
+    {
+        return $this->containers ?? [];
     }
 }
 

--- a/src/classes/filesystem/storage/queries/JsonStorageQuery.php
+++ b/src/classes/filesystem/storage/queries/JsonStorageQuery.php
@@ -2,8 +2,8 @@
 
 namespace Darling\PHPJsonStorageUtilities\classes\filesystem\storage\queries;
 
-use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\storage\queries\JsonStorageQuery as JsonStorageQueryInterface;
 use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\paths\JsonStorageDirectoryPath;
+use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\storage\queries\JsonStorageQuery as JsonStorageQueryInterface;
 
 class JsonStorageQuery implements JsonStorageQueryInterface
 {

--- a/src/classes/filesystem/storage/queries/JsonStorageQuery.php
+++ b/src/classes/filesystem/storage/queries/JsonStorageQuery.php
@@ -6,6 +6,7 @@ use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\paths\JsonStorageDire
 use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\paths\JsonFilePath;
 use \Darling\PHPJsonStorageUtilities\interfaces\named\identifiers\Owner;
 use \Darling\PHPTextTypes\interfaces\strings\Name;
+use \Darling\PHPTextTypes\interfaces\strings\Id;
 use \Darling\PHPJsonStorageUtilities\interfaces\named\identifiers\Location;
 use \Darling\PHPJsonStorageUtilities\interfaces\named\identifiers\Container;
 use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\storage\queries\JsonStorageQuery as JsonStorageQueryInterface;
@@ -22,6 +23,7 @@ class JsonStorageQuery implements JsonStorageQueryInterface
      * @param array<int, Container>|null $containers
      * @param array<int, Owner>|null $owners
      * @param array<int, Name>|null $names
+     * @param array<int, Id>|null $ids
      *
      */
     public function __construct(
@@ -31,6 +33,7 @@ class JsonStorageQuery implements JsonStorageQueryInterface
         private array|null $containers = null,
         private array|null $owners = null,
         private array|null $names = null,
+        private array|null $ids = null,
     ) { }
 
     public function jsonStorageDirectoryPaths(): array
@@ -62,5 +65,11 @@ class JsonStorageQuery implements JsonStorageQueryInterface
     {
         return $this->names ?? [];
     }
+
+    public function ids(): array
+    {
+        return $this->ids ?? [];
+    }
+
 }
 

--- a/src/classes/filesystem/storage/queries/JsonStorageQuery.php
+++ b/src/classes/filesystem/storage/queries/JsonStorageQuery.php
@@ -4,7 +4,8 @@ namespace Darling\PHPJsonStorageUtilities\classes\filesystem\storage\queries;
 
 use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\paths\JsonStorageDirectoryPath;
 use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\paths\JsonFilePath;
-use \Darling\PHPJsonStorageUtilities\classes\named\identifiers\Owner;
+use \Darling\PHPJsonStorageUtilities\interfaces\named\identifiers\Owner;
+use \Darling\PHPTextTypes\interfaces\strings\Name;
 use \Darling\PHPJsonStorageUtilities\interfaces\named\identifiers\Location;
 use \Darling\PHPJsonStorageUtilities\interfaces\named\identifiers\Container;
 use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\storage\queries\JsonStorageQuery as JsonStorageQueryInterface;
@@ -20,6 +21,7 @@ class JsonStorageQuery implements JsonStorageQueryInterface
      * @param array<int, Location>|null $locations
      * @param array<int, Container>|null $containers
      * @param array<int, Owner>|null $owners
+     * @param array<int, Name>|null $names
      *
      */
     public function __construct(
@@ -28,6 +30,7 @@ class JsonStorageQuery implements JsonStorageQueryInterface
         private array|null $locations = null,
         private array|null $containers = null,
         private array|null $owners = null,
+        private array|null $names = null,
     ) { }
 
     public function jsonStorageDirectoryPaths(): array
@@ -55,5 +58,9 @@ class JsonStorageQuery implements JsonStorageQueryInterface
         return $this->owners ?? [];
     }
 
+    public function names(): array
+    {
+        return $this->names ?? [];
+    }
 }
 

--- a/src/interfaces/collections/ContainerCollection.php
+++ b/src/interfaces/collections/ContainerCollection.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Darling\PHPJsonStorageUtilities\interfaces\collections;
+
+use \Darling\PHPJsonStorageUtilities\interfaces\named\identifiers\Container;
+
+interface ContainerCollection
+{
+
+    /**
+     * Return a numerically indexed array of Container instances.
+     *
+     * @return array<int, Container>
+     *
+     */
+    public function collection(): array;
+
+}

--- a/src/interfaces/collections/IdCollection.php
+++ b/src/interfaces/collections/IdCollection.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Darling\PHPJsonStorageUtilities\interfaces\collections;
+
+use \Darling\PHPTextTypes\interfaces\strings\Id;
+
+interface IdCollection
+{
+
+    /**
+     * Return a numerically indexed array of Id
+     * instances.
+     *
+     * @return array<int, Id>
+     *
+     */
+    public function collection(): array;
+
+}

--- a/src/interfaces/collections/JsonFilePathCollection.php
+++ b/src/interfaces/collections/JsonFilePathCollection.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Darling\PHPJsonStorageUtilities\interfaces\collections;
+
+use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\paths\JsonFilePath;
+
+interface JsonFilePathCollection
+{
+
+    /**
+     * Return a numerically indexed array of JsonFilePath
+     * instances.
+     *
+     * @return array<int, JsonFilePath>
+     *
+     */
+    public function collection(): array;
+
+}

--- a/src/interfaces/collections/JsonStorageDirectoryPathCollection.php
+++ b/src/interfaces/collections/JsonStorageDirectoryPathCollection.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Darling\PHPJsonStorageUtilities\interfaces\collections;
+
+use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\paths\JsonStorageDirectoryPath;
+
+interface JsonStorageDirectoryPathCollection
+{
+
+    /**
+     * Return a numerically indexed array of JsonStorageDirectoryPath
+     * instances.
+     *
+     * @return array<int, JsonStorageDirectoryPath>
+     *
+     */
+    public function collection(): array;
+
+}

--- a/src/interfaces/collections/LocationCollection.php
+++ b/src/interfaces/collections/LocationCollection.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Darling\PHPJsonStorageUtilities\interfaces\collections;
+
+use \Darling\PHPJsonStorageUtilities\interfaces\named\identifiers\Location;
+
+interface LocationCollection
+{
+
+    /**
+     * Return a numerically indexed array of Location
+     * instances.
+     *
+     * @return array<int, Location>
+     *
+     */
+    public function collection(): array;
+
+}

--- a/src/interfaces/collections/NameCollection.php
+++ b/src/interfaces/collections/NameCollection.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Darling\PHPJsonStorageUtilities\interfaces\collections;
+
+use \Darling\PHPTextTypes\classes\strings\Name;
+
+interface NameCollection
+{
+
+    /**
+     * Return a numerically indexed array of Name instances.
+     *
+     * @return array<int, Name>
+     *
+     */
+    public function collection(): array;
+
+}

--- a/src/interfaces/collections/OwnerCollection.php
+++ b/src/interfaces/collections/OwnerCollection.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Darling\PHPJsonStorageUtilities\interfaces\collections;
+
+use \Darling\PHPJsonStorageUtilities\interfaces\named\identifiers\Owner;
+
+interface OwnerCollection
+{
+
+    /**
+     * Return a numerically indexed array of Owner instances.
+     *
+     * @return array<int, Owner>
+     *
+     */
+    public function collection(): array;
+
+}

--- a/src/interfaces/filesystem/storage/queries/JsonStorageQuery.php
+++ b/src/interfaces/filesystem/storage/queries/JsonStorageQuery.php
@@ -5,6 +5,7 @@ namespace Darling\PHPJsonStorageUtilities\interfaces\filesystem\storage\queries;
 use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\paths\JsonStorageDirectoryPath;
 use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\paths\JsonFilePath;
 use \Darling\PHPJsonStorageUtilities\interfaces\named\identifiers\Location;
+use \Darling\PHPJsonStorageUtilities\classes\named\identifiers\Owner;
 use \Darling\PHPJsonStorageUtilities\interfaces\named\identifiers\Container;
 
 /**
@@ -48,13 +49,22 @@ interface JsonStorageQuery
     public function locations(): array;
 
     /**
-     * Return an array of Location instances that will determine
+     * Return an array of Container instances that will determine
      * which containers will be queried.
      *
      * @return array<int, Container>
      *
      */
     public function containers(): array;
+
+    /**
+     * Return an array of Owner instances that will determine
+     * which owners will be queried.
+     *
+     * @return array<int, Owner>
+     *
+     */
+    public function owners(): array;
 
 }
 

--- a/src/interfaces/filesystem/storage/queries/JsonStorageQuery.php
+++ b/src/interfaces/filesystem/storage/queries/JsonStorageQuery.php
@@ -3,6 +3,7 @@
 namespace Darling\PHPJsonStorageUtilities\interfaces\filesystem\storage\queries;
 
 use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\paths\JsonStorageDirectoryPath;
+use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\paths\JsonFilePath;
 
 /**
  * Description of this interface.
@@ -19,12 +20,21 @@ interface JsonStorageQuery
 
     /**
      * Return an array of JsonStorageDirectoryPath instances that
-     * will determine which Json storage directory's will be queried.
+     * will determine which Json storage directories will be queried.
      *
      * @return array<int, JsonStorageDirectoryPath>
      *
      */
     public function jsonStorageDirectoryPaths(): array;
+
+    /**
+     * Return an array of JsonFilePath instances that will determine
+     * which JsonFilePath will be queried.
+     *
+     * @return array<int, JsonFilePath>
+     *
+     */
+    public function jsonFilePaths(): array;
 
 }
 

--- a/src/interfaces/filesystem/storage/queries/JsonStorageQuery.php
+++ b/src/interfaces/filesystem/storage/queries/JsonStorageQuery.php
@@ -4,6 +4,7 @@ namespace Darling\PHPJsonStorageUtilities\interfaces\filesystem\storage\queries;
 
 use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\paths\JsonStorageDirectoryPath;
 use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\paths\JsonFilePath;
+use \Darling\PHPJsonStorageUtilities\interfaces\named\identifiers\Location;
 
 /**
  * Description of this interface.
@@ -29,12 +30,21 @@ interface JsonStorageQuery
 
     /**
      * Return an array of JsonFilePath instances that will determine
-     * which JsonFilePath will be queried.
+     * which JsonFilePaths will be queried.
      *
      * @return array<int, JsonFilePath>
      *
      */
     public function jsonFilePaths(): array;
+
+    /**
+     * Return an array of Location instances that will determine
+     * which locations will be queried.
+     *
+     * @return array<int, Location>
+     *
+     */
+    public function locations(): array;
 
 }
 

--- a/src/interfaces/filesystem/storage/queries/JsonStorageQuery.php
+++ b/src/interfaces/filesystem/storage/queries/JsonStorageQuery.php
@@ -5,6 +5,7 @@ namespace Darling\PHPJsonStorageUtilities\interfaces\filesystem\storage\queries;
 use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\paths\JsonStorageDirectoryPath;
 use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\paths\JsonFilePath;
 use \Darling\PHPJsonStorageUtilities\interfaces\named\identifiers\Location;
+use \Darling\PHPJsonStorageUtilities\interfaces\named\identifiers\Container;
 
 /**
  * Description of this interface.
@@ -45,6 +46,15 @@ interface JsonStorageQuery
      *
      */
     public function locations(): array;
+
+    /**
+     * Return an array of Location instances that will determine
+     * which containers will be queried.
+     *
+     * @return array<int, Container>
+     *
+     */
+    public function containers(): array;
 
 }
 

--- a/src/interfaces/filesystem/storage/queries/JsonStorageQuery.php
+++ b/src/interfaces/filesystem/storage/queries/JsonStorageQuery.php
@@ -8,6 +8,7 @@ use \Darling\PHPJsonStorageUtilities\interfaces\named\identifiers\Location;
 use \Darling\PHPJsonStorageUtilities\interfaces\named\identifiers\Owner;
 use \Darling\PHPJsonStorageUtilities\interfaces\named\identifiers\Container;
 use \Darling\PHPTextTypes\interfaces\strings\Name;
+use \Darling\PHPTextTypes\interfaces\strings\Id;
 
 /**
  * Description of this interface.
@@ -76,5 +77,13 @@ interface JsonStorageQuery
      */
     public function names(): array;
 
+    /**
+     * Return an array of Id instances that will determine
+     * which ids will be queried.
+     *
+     * @return array<int, Id>
+     *
+     */
+    public function ids(): array;
 }
 

--- a/src/interfaces/filesystem/storage/queries/JsonStorageQuery.php
+++ b/src/interfaces/filesystem/storage/queries/JsonStorageQuery.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Darling\PHPJsonStorageUtilities\interfaces\filesystem\storage\queries;
+
+use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\paths\JsonStorageDirectoryPath;
+
+/**
+ * Description of this interface.
+ *
+ * @example
+ *
+ * ```
+ *
+ * ```
+ */
+interface JsonStorageQuery
+{
+
+
+    /**
+     * Return an array of JsonStorageDirectoryPath instances that
+     * will determine which Json storage directory's will be queried.
+     *
+     * @return array<int, JsonStorageDirectoryPath>
+     *
+     */
+    public function jsonStorageDirectoryPaths(): array;
+
+}
+

--- a/src/interfaces/filesystem/storage/queries/JsonStorageQuery.php
+++ b/src/interfaces/filesystem/storage/queries/JsonStorageQuery.php
@@ -5,8 +5,9 @@ namespace Darling\PHPJsonStorageUtilities\interfaces\filesystem\storage\queries;
 use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\paths\JsonStorageDirectoryPath;
 use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\paths\JsonFilePath;
 use \Darling\PHPJsonStorageUtilities\interfaces\named\identifiers\Location;
-use \Darling\PHPJsonStorageUtilities\classes\named\identifiers\Owner;
+use \Darling\PHPJsonStorageUtilities\interfaces\named\identifiers\Owner;
 use \Darling\PHPJsonStorageUtilities\interfaces\named\identifiers\Container;
+use \Darling\PHPTextTypes\interfaces\strings\Name;
 
 /**
  * Description of this interface.
@@ -65,6 +66,15 @@ interface JsonStorageQuery
      *
      */
     public function owners(): array;
+
+    /**
+     * Return an array of Name instances that will determine
+     * which names will be queried.
+     *
+     * @return array<int, Name>
+     *
+     */
+    public function names(): array;
 
 }
 

--- a/tests/classes/collections/ContainerCollectionTest.php
+++ b/tests/classes/collections/ContainerCollectionTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Darling\PHPJsonStorageUtilities\tests\classes\collections;
+
+use \Darling\PHPJsonStorageUtilities\classes\collections\ContainerCollection;
+use \Darling\PHPJsonStorageUtilities\classes\named\identifiers\Container;
+use \Darling\PHPJsonStorageUtilities\tests\PHPJsonStorageUtilitiesTest;
+use \Darling\PHPJsonStorageUtilities\tests\interfaces\collections\ContainerCollectionTestTrait;
+use \Darling\PHPTextTypes\classes\strings\ClassString;
+use \Darling\PHPTextTypes\classes\strings\Name;
+use \Darling\PHPTextTypes\classes\strings\Text;
+
+class ContainerCollectionTest extends PHPJsonStorageUtilitiesTest
+{
+
+    /**
+     * The ContainerCollectionTestTrait defines common tests for
+     * implementations of the
+     * Darling\PHPJsonStorageUtilities\interfaces\collections\ContainerCollection
+     * interface.
+     *
+     * @see ContainerCollectionTestTrait
+     *
+     */
+    use ContainerCollectionTestTrait;
+
+    public function setUp(): void
+    {
+        $this->setExpectedCollection(
+            [
+                new Container(
+                    new ClassString(Name::class),
+                ),
+                new Container(
+                    new ClassString(Text::class),
+                ),
+                new Container(
+                    new ClassString(ClassString::class),
+                ),
+                new Container(
+                    new ClassString(ContainerCollection::class),
+                ),
+                new Container(
+                    new ClassString(Container::class),
+                ),
+            ]
+        );
+        $this->setContainerCollectionTestInstance(
+            new ContainerCollection(
+                ...$this->expectedCollection(),
+            )
+        );
+    }
+
+}
+

--- a/tests/classes/collections/IdCollectionTest.php
+++ b/tests/classes/collections/IdCollectionTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Darling\PHPJsonStorageUtilities\tests\classes\collections;
+
+use \Darling\PHPJsonStorageUtilities\classes\collections\IdCollection;
+use \Darling\PHPJsonStorageUtilities\tests\PHPJsonStorageUtilitiesTest;
+use \Darling\PHPJsonStorageUtilities\tests\interfaces\collections\IdCollectionTestTrait;
+use \Darling\PHPTextTypes\classes\strings\Id;
+use \Darling\PHPTextTypes\classes\strings\Name;
+use \Darling\PHPTextTypes\classes\strings\Text;
+
+class IdCollectionTest extends PHPJsonStorageUtilitiesTest
+{
+
+    /**
+     * The IdCollectionTestTrait defines
+     * common tests for implementations of the
+     * Darling\PHPJsonStorageUtilities\interfaces\collections\IdCollection
+     * interface.
+     *
+     * @see IdCollectionTestTrait
+     *
+     */
+    use IdCollectionTestTrait;
+
+    public function setUp(): void
+    {
+        $this->setExpectedCollection(
+            [
+                new Id(),
+                new Id(),
+                new Id(),
+                new Id(),
+                new Id(),
+            ]
+        );
+        $this->setIdCollectionTestInstance(
+            new IdCollection(
+                ...$this->expectedCollection(),
+            )
+        );
+    }
+
+}
+

--- a/tests/classes/collections/JsonFilePathCollectionTest.php
+++ b/tests/classes/collections/JsonFilePathCollectionTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Darling\PHPJsonStorageUtilities\tests\classes\collections;
+
+use \Darling\PHPJsonStorageUtilities\classes\named\identifiers\Owner;
+use \Darling\PHPJsonStorageUtilities\classes\named\identifiers\Location;
+use \Darling\PHPJsonStorageUtilities\classes\named\identifiers\Container;
+use \Darling\PHPJsonStorageUtilities\classes\collections\JsonFilePathCollection;
+use \Darling\PHPJsonStorageUtilities\classes\filesystem\paths\JsonFilePath;
+use \Darling\PHPJsonStorageUtilities\classes\filesystem\paths\JsonStorageDirectoryPath;
+use \Darling\PHPJsonStorageUtilities\tests\PHPJsonStorageUtilitiesTest;
+use \Darling\PHPJsonStorageUtilities\tests\interfaces\collections\JsonFilePathCollectionTestTrait;
+use \Darling\PHPTextTypes\classes\strings\Name;
+use \Darling\PHPTextTypes\classes\strings\Id;
+use \Darling\PHPTextTypes\classes\strings\Text;
+use \Darling\PHPTextTypes\classes\strings\ClassString;
+
+class JsonFilePathCollectionTest extends PHPJsonStorageUtilitiesTest
+{
+
+    /**
+     * The JsonFilePathCollectionTestTrait defines
+     * common tests for implementations of the
+     * Darling\PHPJsonStorageUtilities\interfaces\collections\JsonFilePathCollection
+     * interface.
+     *
+     * @see JsonFilePathCollectionTestTrait
+     *
+     */
+    use JsonFilePathCollectionTestTrait;
+
+    public function setUp(): void
+    {
+        $this->setExpectedCollection(
+            [
+                new JsonFilePath(
+                    new JsonStorageDirectoryPath(new Name(new Text($this->randomChars()))),
+                    new Location(new Name(new Text($this->randomChars()))),
+                    new Container(new ClassString(Id::class)),
+                    new Owner(new Name(new Text($this->randomChars()))),
+                    new Name(new Text($this->randomChars())),
+                    new Id(),
+                ),
+            ]
+        );
+        $this->setJsonFilePathCollectionTestInstance(
+            new JsonFilePathCollection(
+                ...$this->expectedCollection(),
+            )
+        );
+    }
+
+}
+

--- a/tests/classes/collections/JsonStorageDirectoryPathCollectionTest.php
+++ b/tests/classes/collections/JsonStorageDirectoryPathCollectionTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Darling\PHPJsonStorageUtilities\tests\classes\collections;
+
+use \Darling\PHPJsonStorageUtilities\classes\collections\JsonStorageDirectoryPathCollection;
+use \Darling\PHPTextTypes\classes\strings\Name;
+use \Darling\PHPTextTypes\classes\strings\Text;
+use \Darling\PHPJsonStorageUtilities\tests\PHPJsonStorageUtilitiesTest;
+use \Darling\PHPJsonStorageUtilities\tests\interfaces\collections\JsonStorageDirectoryPathCollectionTestTrait;
+use \Darling\PHPJsonStorageUtilities\classes\filesystem\paths\JsonStorageDirectoryPath;
+
+class JsonStorageDirectoryPathCollectionTest extends PHPJsonStorageUtilitiesTest
+{
+
+    /**
+     * The JsonStorageDirectoryPathCollectionTestTrait defines
+     * common tests for implementations of the
+     * Darling\PHPJsonStorageUtilities\interfaces\collections\JsonStorageDirectoryPathCollection
+     * interface.
+     *
+     * @see JsonStorageDirectoryPathCollectionTestTrait
+     *
+     */
+    use JsonStorageDirectoryPathCollectionTestTrait;
+
+    public function setUp(): void
+    {
+        $this->setExpectedCollection(
+            [
+                new JsonStorageDirectoryPath(
+                    new Name(new Text($this->randomChars())),
+                ),
+                new JsonStorageDirectoryPath(
+                    new Name(new Text($this->randomChars())),
+                ),
+                new JsonStorageDirectoryPath(
+                    new Name(new Text($this->randomChars())),
+                ),
+                new JsonStorageDirectoryPath(
+                    new Name(new Text($this->randomChars())),
+                ),
+                new JsonStorageDirectoryPath(
+                    new Name(new Text($this->randomChars())),
+                ),
+            ]
+        );
+        $this->setJsonStorageDirectoryPathCollectionTestInstance(
+            new JsonStorageDirectoryPathCollection(
+                ...$this->expectedCollection(),
+            )
+        );
+    }
+}
+

--- a/tests/classes/collections/JsonStorageDirectoryPathCollectionTest.php
+++ b/tests/classes/collections/JsonStorageDirectoryPathCollectionTest.php
@@ -3,11 +3,11 @@
 namespace Darling\PHPJsonStorageUtilities\tests\classes\collections;
 
 use \Darling\PHPJsonStorageUtilities\classes\collections\JsonStorageDirectoryPathCollection;
-use \Darling\PHPTextTypes\classes\strings\Name;
-use \Darling\PHPTextTypes\classes\strings\Text;
+use \Darling\PHPJsonStorageUtilities\classes\filesystem\paths\JsonStorageDirectoryPath;
 use \Darling\PHPJsonStorageUtilities\tests\PHPJsonStorageUtilitiesTest;
 use \Darling\PHPJsonStorageUtilities\tests\interfaces\collections\JsonStorageDirectoryPathCollectionTestTrait;
-use \Darling\PHPJsonStorageUtilities\classes\filesystem\paths\JsonStorageDirectoryPath;
+use \Darling\PHPTextTypes\classes\strings\Name;
+use \Darling\PHPTextTypes\classes\strings\Text;
 
 class JsonStorageDirectoryPathCollectionTest extends PHPJsonStorageUtilitiesTest
 {
@@ -50,5 +50,6 @@ class JsonStorageDirectoryPathCollectionTest extends PHPJsonStorageUtilitiesTest
             )
         );
     }
+
 }
 

--- a/tests/classes/collections/LocationCollectionTest.php
+++ b/tests/classes/collections/LocationCollectionTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Darling\PHPJsonStorageUtilities\tests\classes\collections;
+
+use \Darling\PHPJsonStorageUtilities\classes\collections\LocationCollection;
+use \Darling\PHPJsonStorageUtilities\classes\named\identifiers\Location;
+use \Darling\PHPJsonStorageUtilities\tests\PHPJsonStorageUtilitiesTest;
+use \Darling\PHPJsonStorageUtilities\tests\interfaces\collections\LocationCollectionTestTrait;
+use \Darling\PHPTextTypes\classes\strings\Name;
+use \Darling\PHPTextTypes\classes\strings\Text;
+
+class LocationCollectionTest extends PHPJsonStorageUtilitiesTest
+{
+
+    /**
+     * The LocationCollectionTestTrait defines common tests for
+     * implementations of the
+     * Darling\PHPJsonStorageUtilities\interfaces\collections\LocationCollection
+     * interface.
+     *
+     * @see LocationCollectionTestTrait
+     *
+     */
+    use LocationCollectionTestTrait;
+
+    public function setUp(): void
+    {
+        $this->setExpectedCollection(
+            [
+                new Location(
+                    new Name(new Text($this->randomChars())),
+                ),
+                new Location(
+                    new Name(new Text($this->randomChars())),
+                ),
+                new Location(
+                    new Name(new Text($this->randomChars())),
+                ),
+                new Location(
+                    new Name(new Text($this->randomChars())),
+                ),
+                new Location(
+                    new Name(new Text($this->randomChars())),
+                ),
+            ]
+        );
+        $this->setLocationCollectionTestInstance(
+            new LocationCollection(
+                ...$this->expectedCollection(),
+            )
+        );
+    }
+
+}
+

--- a/tests/classes/collections/NameCollectionTest.php
+++ b/tests/classes/collections/NameCollectionTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Darling\PHPJsonStorageUtilities\tests\classes\collections;
+
+use \Darling\PHPJsonStorageUtilities\classes\collections\NameCollection;
+use \Darling\PHPJsonStorageUtilities\tests\PHPJsonStorageUtilitiesTest;
+use \Darling\PHPJsonStorageUtilities\tests\interfaces\collections\NameCollectionTestTrait;
+use \Darling\PHPTextTypes\classes\strings\Name;
+use \Darling\PHPTextTypes\classes\strings\Text;
+
+class NameCollectionTest extends PHPJsonStorageUtilitiesTest
+{
+
+    /**
+     * The NameCollectionTestTrait defines common tests for
+     * implementations of the
+     * Darling\PHPJsonStorageUtilities\interfaces\collections\NameCollection
+     * interface.
+     *
+     * @see NameCollectionTestTrait
+     *
+     */
+    use NameCollectionTestTrait;
+
+    public function setUp(): void
+    {
+        $this->setExpectedCollection(
+            [
+                new Name(new Text($this->randomChars())),
+                new Name(new Text($this->randomChars())),
+                new Name(new Text($this->randomChars())),
+                new Name(new Text($this->randomChars())),
+                new Name(new Text($this->randomChars())),
+            ]
+        );
+        $this->setNameCollectionTestInstance(
+            new NameCollection(
+                ...$this->expectedCollection(),
+            )
+        );
+    }
+
+}
+

--- a/tests/classes/collections/OwnerCollectionTest.php
+++ b/tests/classes/collections/OwnerCollectionTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Darling\PHPJsonStorageUtilities\tests\classes\collections;
+
+use \Darling\PHPJsonStorageUtilities\classes\collections\OwnerCollection;
+use \Darling\PHPJsonStorageUtilities\classes\named\identifiers\Owner;
+use \Darling\PHPJsonStorageUtilities\tests\PHPJsonStorageUtilitiesTest;
+use \Darling\PHPJsonStorageUtilities\tests\interfaces\collections\OwnerCollectionTestTrait;
+use \Darling\PHPTextTypes\classes\strings\Name;
+use \Darling\PHPTextTypes\classes\strings\Text;
+
+class OwnerCollectionTest extends PHPJsonStorageUtilitiesTest
+{
+
+    /**
+     * The OwnerCollectionTestTrait defines common tests for
+     * implementations of the
+     * Darling\PHPJsonStorageUtilities\interfaces\collections\OwnerCollection
+     * interface.
+     *
+     * @see OwnerCollectionTestTrait
+     *
+     */
+    use OwnerCollectionTestTrait;
+
+    public function setUp(): void
+    {
+        $this->setExpectedCollection(
+            [
+                new Owner(
+                    new Name(new Text($this->randomChars())),
+                ),
+                new Owner(
+                    new Name(new Text($this->randomChars())),
+                ),
+                new Owner(
+                    new Name(new Text($this->randomChars())),
+                ),
+                new Owner(
+                    new Name(new Text($this->randomChars())),
+                ),
+                new Owner(
+                    new Name(new Text($this->randomChars())),
+                ),
+            ]
+        );
+        $this->setOwnerCollectionTestInstance(
+            new OwnerCollection(
+                ...$this->expectedCollection(),
+            )
+        );
+    }
+
+}
+

--- a/tests/classes/filesystem/storage/queries/JsonStorageQueryTest.php
+++ b/tests/classes/filesystem/storage/queries/JsonStorageQueryTest.php
@@ -86,6 +86,12 @@ class JsonStorageQueryTest extends PHPJsonStorageUtilitiesTest
             new Name(new Name(new Text($this->randomChars()))),
         ];
         $this->setExpectedNames($expectedNames);
+        $expectedIds = [
+            new Id(),
+            new Id(),
+            new Id(),
+        ];
+        $this->setExpectedIds($expectedIds);
         $this->setJsonStorageQueryTestInstance(
             new JsonStorageQuery(
                 jsonStorageDirectoryPaths: $expectedJsonStorageDirectoryPaths,
@@ -94,6 +100,7 @@ class JsonStorageQueryTest extends PHPJsonStorageUtilitiesTest
                 containers: $expectedContainers,
                 owners: $expectedOwners,
                 names: $expectedNames,
+                ids: $expectedIds,
             )
         );
     }

--- a/tests/classes/filesystem/storage/queries/JsonStorageQueryTest.php
+++ b/tests/classes/filesystem/storage/queries/JsonStorageQueryTest.php
@@ -33,25 +33,13 @@ class JsonStorageQueryTest extends PHPJsonStorageUtilitiesTest
     {
         $expectedJsonStorageDirectoryPaths = [
             new JsonStorageDirectoryPath(
-                new Name(
-                    new Text(
-                        $this->randomChars()
-                    )
-                )
+                new Name(new Text($this->randomChars()))
             ),
             new JsonStorageDirectoryPath(
-                new Name(
-                    new Text(
-                        $this->randomChars()
-                    )
-                )
+                new Name(new Text($this->randomChars()))
             ),
             new JsonStorageDirectoryPath(
-                new Name(
-                    new Text(
-                        $this->randomChars()
-                    )
-                )
+                new Name(new Text($this->randomChars()))
             ),
         ];
         $this->setExpectedJsonStorageDirectoryPaths(
@@ -80,11 +68,18 @@ class JsonStorageQueryTest extends PHPJsonStorageUtilitiesTest
             new Location(new Name(new Text($this->randomChars()))),
         ];
         $this->setExpectedLocations($expectedLocations);
+        $expectedContainers = [
+            new Container(new ClassString(Name::class)),
+            new Container(new ClassString(Text::class)),
+            new Container(new ClassString(Id::class)),
+        ];
+        $this->setExpectedContainers($expectedContainers);
         $this->setJsonStorageQueryTestInstance(
             new JsonStorageQuery(
                 jsonStorageDirectoryPaths: $expectedJsonStorageDirectoryPaths,
                 jsonFilePaths: $expectedJsonFilePaths,
                 locations: $expectedLocations,
+                containers: $expectedContainers,
             )
         );
     }

--- a/tests/classes/filesystem/storage/queries/JsonStorageQueryTest.php
+++ b/tests/classes/filesystem/storage/queries/JsonStorageQueryTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Darling\PHPJsonStorageUtilities\tests\classes\filesystem\storage\queries;
+
+use \Darling\PHPJsonStorageUtilities\classes\filesystem\storage\queries\JsonStorageQuery;
+use \Darling\PHPJsonStorageUtilities\tests\PHPJsonStorageUtilitiesTest;
+use \Darling\PHPJsonStorageUtilities\tests\interfaces\filesystem\storage\queries\JsonStorageQueryTestTrait;
+use \Darling\PHPJsonStorageUtilities\classes\filesystem\paths\JsonStorageDirectoryPath;
+use \Darling\PHPTextTypes\classes\strings\Name;
+use \Darling\PHPTextTypes\classes\strings\Text;
+
+class JsonStorageQueryTest extends PHPJsonStorageUtilitiesTest
+{
+
+    /**
+     * The JsonStorageQueryTestTrait defines
+     * common tests for implementations of the
+     * Darling\PHPJsonStorageUtilities\interfaces\filesystem\storage\queries\JsonStorageQuery
+     * interface.
+     *
+     * @see JsonStorageQueryTestTrait
+     *
+     */
+    use JsonStorageQueryTestTrait;
+
+    public function setUp(): void
+    {
+        $expectedJsonStorageDirectoryPaths = [
+            new JsonStorageDirectoryPath(
+                new Name(
+                    new Text(
+                        $this->randomChars()
+                    )
+                )
+            )
+        ];
+        $this->setExpectedJsonStorageDirectoryPaths(
+            $expectedJsonStorageDirectoryPaths
+        );
+        $this->setJsonStorageQueryTestInstance(
+            new JsonStorageQuery($expectedJsonStorageDirectoryPaths)
+        );
+    }
+}
+

--- a/tests/classes/filesystem/storage/queries/JsonStorageQueryTest.php
+++ b/tests/classes/filesystem/storage/queries/JsonStorageQueryTest.php
@@ -2,10 +2,10 @@
 
 namespace Darling\PHPJsonStorageUtilities\tests\classes\filesystem\storage\queries;
 
+use \Darling\PHPJsonStorageUtilities\classes\filesystem\paths\JsonStorageDirectoryPath;
 use \Darling\PHPJsonStorageUtilities\classes\filesystem\storage\queries\JsonStorageQuery;
 use \Darling\PHPJsonStorageUtilities\tests\PHPJsonStorageUtilitiesTest;
 use \Darling\PHPJsonStorageUtilities\tests\interfaces\filesystem\storage\queries\JsonStorageQueryTestTrait;
-use \Darling\PHPJsonStorageUtilities\classes\filesystem\paths\JsonStorageDirectoryPath;
 use \Darling\PHPTextTypes\classes\strings\Name;
 use \Darling\PHPTextTypes\classes\strings\Text;
 
@@ -13,8 +13,8 @@ class JsonStorageQueryTest extends PHPJsonStorageUtilitiesTest
 {
 
     /**
-     * The JsonStorageQueryTestTrait defines
-     * common tests for implementations of the
+     * The JsonStorageQueryTestTrait defines common tests for
+     * implementations of the
      * Darling\PHPJsonStorageUtilities\interfaces\filesystem\storage\queries\JsonStorageQuery
      * interface.
      *
@@ -32,7 +32,21 @@ class JsonStorageQueryTest extends PHPJsonStorageUtilitiesTest
                         $this->randomChars()
                     )
                 )
-            )
+            ),
+            new JsonStorageDirectoryPath(
+                new Name(
+                    new Text(
+                        $this->randomChars()
+                    )
+                )
+            ),
+            new JsonStorageDirectoryPath(
+                new Name(
+                    new Text(
+                        $this->randomChars()
+                    )
+                )
+            ),
         ];
         $this->setExpectedJsonStorageDirectoryPaths(
             $expectedJsonStorageDirectoryPaths

--- a/tests/classes/filesystem/storage/queries/JsonStorageQueryTest.php
+++ b/tests/classes/filesystem/storage/queries/JsonStorageQueryTest.php
@@ -80,6 +80,12 @@ class JsonStorageQueryTest extends PHPJsonStorageUtilitiesTest
             new Owner(new Name(new Text($this->randomChars()))),
         ];
         $this->setExpectedOwners($expectedOwners);
+        $expectedNames = [
+            new Name(new Name(new Text($this->randomChars()))),
+            new Name(new Name(new Text($this->randomChars()))),
+            new Name(new Name(new Text($this->randomChars()))),
+        ];
+        $this->setExpectedNames($expectedNames);
         $this->setJsonStorageQueryTestInstance(
             new JsonStorageQuery(
                 jsonStorageDirectoryPaths: $expectedJsonStorageDirectoryPaths,
@@ -87,6 +93,7 @@ class JsonStorageQueryTest extends PHPJsonStorageUtilitiesTest
                 locations: $expectedLocations,
                 containers: $expectedContainers,
                 owners: $expectedOwners,
+                names: $expectedNames,
             )
         );
     }

--- a/tests/classes/filesystem/storage/queries/JsonStorageQueryTest.php
+++ b/tests/classes/filesystem/storage/queries/JsonStorageQueryTest.php
@@ -74,10 +74,17 @@ class JsonStorageQueryTest extends PHPJsonStorageUtilitiesTest
             ),
         ];
         $this->setExpectedJsonFilePaths($expectedJsonFilePaths);
+        $expectedLocations = [
+            new Location(new Name(new Text($this->randomChars()))),
+            new Location(new Name(new Text($this->randomChars()))),
+            new Location(new Name(new Text($this->randomChars()))),
+        ];
+        $this->setExpectedLocations($expectedLocations);
         $this->setJsonStorageQueryTestInstance(
             new JsonStorageQuery(
                 jsonStorageDirectoryPaths: $expectedJsonStorageDirectoryPaths,
                 jsonFilePaths: $expectedJsonFilePaths,
+                locations: $expectedLocations,
             )
         );
     }

--- a/tests/classes/filesystem/storage/queries/JsonStorageQueryTest.php
+++ b/tests/classes/filesystem/storage/queries/JsonStorageQueryTest.php
@@ -74,12 +74,19 @@ class JsonStorageQueryTest extends PHPJsonStorageUtilitiesTest
             new Container(new ClassString(Id::class)),
         ];
         $this->setExpectedContainers($expectedContainers);
+        $expectedOwners = [
+            new Owner(new Name(new Text($this->randomChars()))),
+            new Owner(new Name(new Text($this->randomChars()))),
+            new Owner(new Name(new Text($this->randomChars()))),
+        ];
+        $this->setExpectedOwners($expectedOwners);
         $this->setJsonStorageQueryTestInstance(
             new JsonStorageQuery(
                 jsonStorageDirectoryPaths: $expectedJsonStorageDirectoryPaths,
                 jsonFilePaths: $expectedJsonFilePaths,
                 locations: $expectedLocations,
                 containers: $expectedContainers,
+                owners: $expectedOwners,
             )
         );
     }

--- a/tests/classes/filesystem/storage/queries/JsonStorageQueryTest.php
+++ b/tests/classes/filesystem/storage/queries/JsonStorageQueryTest.php
@@ -3,11 +3,17 @@
 namespace Darling\PHPJsonStorageUtilities\tests\classes\filesystem\storage\queries;
 
 use \Darling\PHPJsonStorageUtilities\classes\filesystem\paths\JsonStorageDirectoryPath;
+use \Darling\PHPJsonStorageUtilities\classes\filesystem\paths\JsonFilePath;
 use \Darling\PHPJsonStorageUtilities\classes\filesystem\storage\queries\JsonStorageQuery;
 use \Darling\PHPJsonStorageUtilities\tests\PHPJsonStorageUtilitiesTest;
 use \Darling\PHPJsonStorageUtilities\tests\interfaces\filesystem\storage\queries\JsonStorageQueryTestTrait;
 use \Darling\PHPTextTypes\classes\strings\Name;
+use \Darling\PHPTextTypes\classes\strings\ClassString;
 use \Darling\PHPTextTypes\classes\strings\Text;
+use \Darling\PHPTextTypes\classes\strings\Id;
+use \Darling\PHPJsonStorageUtilities\classes\named\identifiers\Location;
+use \Darling\PHPJsonStorageUtilities\classes\named\identifiers\Owner;
+use \Darling\PHPJsonStorageUtilities\classes\named\identifiers\Container;
 
 class JsonStorageQueryTest extends PHPJsonStorageUtilitiesTest
 {
@@ -51,8 +57,28 @@ class JsonStorageQueryTest extends PHPJsonStorageUtilitiesTest
         $this->setExpectedJsonStorageDirectoryPaths(
             $expectedJsonStorageDirectoryPaths
         );
+        $expectedJsonFilePaths = [
+            new JsonFilePath(
+                new JsonStorageDirectoryPath(
+                    new Name(
+                        new Text(
+                            $this->randomChars()
+                        )
+                    )
+                ),
+                new Location(new Name(new Text($this->randomChars()))),
+                new Container(new ClassString(Name::class)),
+                new Owner(new Name(new Text($this->randomChars()))),
+                new Name(new Text($this->randomChars())),
+                new Id(),
+            ),
+        ];
+        $this->setExpectedJsonFilePaths($expectedJsonFilePaths);
         $this->setJsonStorageQueryTestInstance(
-            new JsonStorageQuery($expectedJsonStorageDirectoryPaths)
+            new JsonStorageQuery(
+                jsonStorageDirectoryPaths: $expectedJsonStorageDirectoryPaths,
+                jsonFilePaths: $expectedJsonFilePaths,
+            )
         );
     }
 }

--- a/tests/interfaces/collections/ContainerCollectionTestTrait.php
+++ b/tests/interfaces/collections/ContainerCollectionTestTrait.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace Darling\PHPJsonStorageUtilities\tests\interfaces\collections;
+
+use \Darling\PHPJsonStorageUtilities\interfaces\collections\ContainerCollection;
+use \Darling\PHPJsonStorageUtilities\interfaces\named\identifiers\Container;
+
+/**
+ * The ContainerCollectionTestTrait defines common tests for
+ * implementations of the ContainerCollection interface.
+ *
+ * @see ContainerCollection
+ *
+ */
+trait ContainerCollectionTestTrait
+{
+
+    /**
+     * @var ContainerCollection $containerLocation An instance of a
+     *                                             ContainerCollection
+     *                                             implementation to
+     *                                             test.
+     */
+    protected ContainerCollection $containerLocation;
+
+    /**
+     * @var array<int, Container> The array of Container instances
+     *                            that is expected to be returned
+     *                            by the ContainerCollection instance
+     *                            being tested's collection() method.
+     */
+    private array $expectedCollection = [];
+
+    /**
+     * Set up an instance of a ContainerCollection implementation to
+     * test.
+     *
+     * This method must set the ContainerCollection
+     * implementation instance to be tested via the
+     * setContainerCollectionTestInstance() method.
+     *
+     * This method must also set the array of Container instances
+     * that is expected to be returned by the ContainerCollection
+     * instance being tested's collection() method via the
+     * setExpectedCollection() method.
+     *
+     * This method may also be used to perform any additional setup
+     * required by the implementation being tested.
+     *
+     * @return void
+     *
+     * @example
+     *
+     * ```
+     * public function setUp(): void
+     * {
+     *     $this->setExpectedCollection(
+     *         [
+     *             new Container(
+     *                 new ClassString(Name::class),
+     *             ),
+     *             new Container(
+     *                 new ClassString(Text::class),
+     *             ),
+     *             new Container(
+     *                 new ClassString(ClassString::class),
+     *             ),
+     *             new Container(
+     *                 new ClassString(ContainerCollection::class),
+     *             ),
+     *             new Container(
+     *                 new ClassString(Container::class),
+     *             ),
+     *         ]
+     *     );
+     *     $this->setContainerCollectionTestInstance(
+     *         new ContainerCollection(
+     *             ...$this->expectedCollection(),
+     *         )
+     *     );
+     * }
+     *
+     * ```
+     *
+     */
+    abstract protected function setUp(): void;
+
+    /**
+     * Return the ContainerCollection implementation instance to test.
+     *
+     * @return ContainerCollection
+     *
+     */
+    protected function containerLocationTestInstance(): ContainerCollection
+    {
+        return $this->containerLocation;
+    }
+
+    /**
+     * Set the ContainerCollection implementation instance to test.
+     *
+     * @param ContainerCollection $containerLocationTestInstance
+     *                                           An instance of an
+     *                                           implementation of
+     *                                           the
+     *                                           ContainerCollection
+     *                                           interface to test.
+     *
+     * @return void
+     *
+     */
+    protected function setContainerCollectionTestInstance(
+        ContainerCollection $containerLocationTestInstance
+    ): void
+    {
+        $this->containerLocation = $containerLocationTestInstance;
+    }
+
+    /**
+     * Set the array of Container instances that is expected to be
+     * returned by the ContainerCollection instance being tested's
+     * collection() method.
+     *
+     * @param array<int, Container> $collection
+     *
+     * @return void
+     *
+     */
+    protected function setExpectedCollection(array $collection): void
+    {
+        $this->expectedCollection = $collection;
+    }
+
+    /**
+     * Return the array of Container instances that is expected to be
+     * returned by the ContainerCollection instance being tested's
+     * collection() method.
+     *
+     * @return array<int, Container>
+     *
+     */
+    protected function expectedCollection(): array
+    {
+        return $this->expectedCollection;
+    }
+
+    /**
+     * Test collection() returns the expected array of Container
+     * instances.
+     *
+     * @return void
+     *
+     * @covers ContainerCollection->collection()
+     *
+     */
+    public function test_collection_returns_the_expected_array_of_Container_instances(): void
+    {
+        $this->assertEquals(
+            $this->expectedCollection(),
+            $this->containerLocationTestInstance()->collection(),
+            $this->testFailedMessage(
+                $this->containerLocationTestInstance(),
+                'collection',
+                'return the expected array of Container instances'
+            ),
+        );
+    }
+
+}
+

--- a/tests/interfaces/collections/IdCollectionTestTrait.php
+++ b/tests/interfaces/collections/IdCollectionTestTrait.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Darling\PHPJsonStorageUtilities\tests\interfaces\collections;
+
+use \Darling\PHPJsonStorageUtilities\interfaces\collections\IdCollection;
+use \Darling\PHPTextTypes\interfaces\strings\Id;
+
+/**
+ * The IdCollectionTestTrait defines common
+ * tests for implementations of the IdCollection
+ * interface.
+ *
+ * @see IdCollection
+ *
+ */
+trait IdCollectionTestTrait
+{
+
+    /**
+     * @var IdCollection $idCollection An instance of a IdCollection
+     *                                 implementation to test.
+     */
+    protected IdCollection $idCollection;
+
+    /**
+     * @var array<int, Id> The array of Id instances that is expected
+     *                     to be returned by the IdCollection instance
+     *                     being tested's collection() method.
+     */
+    private array $expectedCollection = [];
+
+    /**
+     * Set up an instance of a IdCollection implementation to test.
+     *
+     * This method must set the IdCollection implementation instance
+     * to be tested via the setIdCollectionTestInstance() method.
+     *
+     * This method must also set the array of Id instances that is
+     * expected to be returned by the IdCollection instance being
+     * tested's collection() method via the setExpectedCollection()
+     * method.
+     *
+     * This method may also be used to perform any additional setup
+     * required by the implementation being tested.
+     *
+     * @return void
+     *
+     * @example
+     *
+     * ```
+     * public function setUp(): void
+     * {
+     *     $this->setExpectedCollection(
+     *         [
+     *             new Id(),
+     *             new Id(),
+     *             new Id(),
+     *             new Id(),
+     *             new Id(),
+     *         ]
+     *     );
+     *     $this->setIdCollectionTestInstance(
+     *         new IdCollection(
+     *             ...$this->expectedCollection(),
+     *         )
+     *     );
+     * }
+     *
+     * ```
+     *
+     */
+    abstract protected function setUp(): void;
+
+    /**
+     * Return the IdCollection implementation instance to test.
+     *
+     * @return IdCollection
+     *
+     */
+    protected function idCollectionTestInstance(): IdCollection
+    {
+        return $this->idCollection;
+    }
+
+    /**
+     * Set the IdCollection implementation instance to test.
+     *
+     * @param IdCollection $idCollectionTestInstance An instance of an
+     *                                               implementation of
+     *                                               the IdCollection
+     *                                               interface to
+     *                                               test.
+     *
+     * @return void
+     *
+     */
+    protected function setIdCollectionTestInstance(
+        IdCollection $idCollectionTestInstance
+    ): void
+    {
+        $this->idCollection = $idCollectionTestInstance;
+    }
+
+    /**
+     * Set the array of Id instances that is expected to be returned
+     * by the IdCollection instance being tested's collection()
+     * method.
+     *
+     * @param array<int, Id> $collection
+     *
+     * @return void
+     *
+     */
+    protected function setExpectedCollection(array $collection): void
+    {
+        $this->expectedCollection = $collection;
+    }
+
+    /**
+     * Return the array of Id instances that is expected to be
+     * returned by the IdCollection instance being tested's
+     * collection() method.
+     *
+     * @return array<int, Id>
+     *
+     */
+    protected function expectedCollection(): array
+    {
+        return $this->expectedCollection;
+    }
+
+    /**
+     * Test collection() returns the expected array of Id instances.
+     *
+     * @return void
+     *
+     * @covers IdCollection->collection()
+     *
+     */
+    public function test_collection_returns_the_expected_array_of_Id_instances(): void
+    {
+        $this->assertEquals(
+            $this->expectedCollection(),
+            $this->idCollectionTestInstance()->collection(),
+            $this->testFailedMessage(
+                $this->idCollectionTestInstance(),
+                'collection',
+                'return the expected array of Id instances'
+            ),
+        );
+    }
+
+}
+

--- a/tests/interfaces/collections/JsonFilePathCollectionTestTrait.php
+++ b/tests/interfaces/collections/JsonFilePathCollectionTestTrait.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace Darling\PHPJsonStorageUtilities\tests\interfaces\collections;
+
+use \Darling\PHPJsonStorageUtilities\interfaces\collections\JsonFilePathCollection;
+use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\paths\JsonFilePath;
+
+/**
+ * The JsonFilePathCollectionTestTrait defines common
+ * tests for implementations of the JsonFilePathCollection
+ * interface.
+ *
+ * @see JsonFilePathCollection
+ *
+ */
+trait JsonFilePathCollectionTestTrait
+{
+
+    /**
+     * @var JsonFilePathCollection $jsonFilePathCollection
+     *                              An instance of a
+     *                              JsonFilePathCollection
+     *                              implementation to test.
+     */
+    protected JsonFilePathCollection $jsonFilePathCollection;
+
+    /**
+     * @var array<int, JsonFilePath> The array of
+     *                                           JsonFilePath
+     *                                           instances that is
+     *                                           expected to be
+     *                                           returned by the
+     *                                           JsonFilePathCollection
+     *                                           instance being
+     *                                           tested's collection()
+     *                                           method.
+     */
+    private array $expectedCollection = [];
+
+    /**
+     * Set up an instance of a JsonFilePathCollection
+     * implementation to test.
+     *
+     * This method must set the JsonFilePathCollection
+     * implementation instance to be tested via the
+     * setJsonFilePathCollectionTestInstance() method.
+     *
+     * This method must also set the array of JsonFilePath
+     * instances that is expected to be returned by the
+     * JsonFilePathCollection instance being tested's
+     * collection() method via the setExpectedCollection() method.
+     *
+     * This method may also be used to perform any additional setup
+     * required by the implementation being tested.
+     *
+     * @return void
+     *
+     * @example
+     *
+     * ```
+     * public function setUp(): void
+     * {
+     *     $this->setExpectedCollection(
+     *         [
+     *             new JsonFilePath(
+     *                 new Name(new Text($this->randomChars())),
+     *             ),
+     *             new JsonFilePath(
+     *                 new Name(new Text($this->randomChars())),
+     *             ),
+     *             new JsonFilePath(
+     *                 new Name(new Text($this->randomChars())),
+     *             ),
+     *             new JsonFilePath(
+     *                 new Name(new Text($this->randomChars())),
+     *             ),
+     *             new JsonFilePath(
+     *                 new Name(new Text($this->randomChars())),
+     *             ),
+     *         ]
+     *     );
+     *     $this->setJsonFilePathCollectionTestInstance(
+     *         new JsonFilePathCollection(
+     *             ...$this->expectedCollection(),
+     *         )
+     *     );
+     * }
+     *
+     * ```
+     *
+     */
+    abstract protected function setUp(): void;
+
+    /**
+     * Return the JsonFilePathCollection implementation
+     * instance to test.
+     *
+     * @return JsonFilePathCollection
+     *
+     */
+    protected function jsonFilePathCollectionTestInstance(): JsonFilePathCollection
+    {
+        return $this->jsonFilePathCollection;
+    }
+
+    /**
+     * Set the JsonFilePathCollection implementation
+     * instance to test.
+     *
+     * @param JsonFilePathCollection $jsonFilePathCollectionTestInstance
+     *                                           An instance of an
+     *                                           implementation of
+     *                                           the
+     *                                           JsonFilePathCollection
+     *                                           interface to test.
+     *
+     * @return void
+     *
+     */
+    protected function setJsonFilePathCollectionTestInstance(
+        JsonFilePathCollection $jsonFilePathCollectionTestInstance
+    ): void
+    {
+        $this->jsonFilePathCollection = $jsonFilePathCollectionTestInstance;
+    }
+
+    /**
+     * Set the array of JsonFilePath instances that is
+     * expected to be returned by the JsonFilePathCollection
+     * instance being tested's collection() method.
+     *
+     * @param array<int, JsonFilePath> $collection
+     *
+     * @return void
+     *
+     */
+    protected function setExpectedCollection(array $collection): void
+    {
+        $this->expectedCollection = $collection;
+    }
+
+    /**
+     * Return the array of JsonFilePath instances that is
+     * expected to be returned by the JsonFilePathCollection
+     * instance being tested's collection() method.
+     *
+     * @return array<int, JsonFilePath>
+     *
+     */
+    protected function expectedCollection(): array
+    {
+        return $this->expectedCollection;
+    }
+
+    /**
+     * Test collection() returns the expected array of
+     * JsonFilePath instances.
+     *
+     * @return void
+     *
+     * @covers JsonFilePathCollection->collection()
+     *
+     */
+    public function test_collection_returns_the_expected_array_of_JsonFilePath_instances(): void
+    {
+        $this->assertEquals(
+            $this->expectedCollection(),
+            $this->jsonFilePathCollectionTestInstance()->collection(),
+            $this->testFailedMessage(
+                $this->jsonFilePathCollectionTestInstance(),
+                'collection',
+                'return the expected array of JsonFilePath instances'
+            ),
+        );
+    }
+
+}
+

--- a/tests/interfaces/collections/JsonStorageDirectoryPathCollectionTestTrait.php
+++ b/tests/interfaces/collections/JsonStorageDirectoryPathCollectionTestTrait.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Darling\PHPJsonStorageUtilities\tests\interfaces\collections;
+
+use \Darling\PHPJsonStorageUtilities\interfaces\collections\JsonStorageDirectoryPathCollection;
+use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\paths\JsonStorageDirectoryPath;
+
+/**
+ * The JsonStorageDirectoryPathCollectionTestTrait defines common tests for
+ * implementations of the JsonStorageDirectoryPathCollection interface.
+ *
+ * @see JsonStorageDirectoryPathCollection
+ *
+ */
+trait JsonStorageDirectoryPathCollectionTestTrait
+{
+
+    /**
+     * @var JsonStorageDirectoryPathCollection $jsonStorageDirectoryPathCollection
+     *                              An instance of a
+     *                              JsonStorageDirectoryPathCollection
+     *                              implementation to test.
+     */
+    protected JsonStorageDirectoryPathCollection $jsonStorageDirectoryPathCollection;
+
+    /**
+     * @var array<int, JsonStorageDirectoryPath>
+     */
+    private array $expectedCollection = [];
+
+    /**
+     * Set up an instance of a JsonStorageDirectoryPathCollection implementation to test.
+     *
+     * This method must also set the JsonStorageDirectoryPathCollection implementation instance
+     * to be tested via the setJsonStorageDirectoryPathCollectionTestInstance() method.
+     *
+     * This method may also be used to perform any additional setup
+     * required by the implementation being tested.
+     *
+     * @return void
+     *
+     * @example
+     *
+     * ```
+     * protected function setUp(): void
+     * {
+     *     $this->setJsonStorageDirectoryPathCollectionTestInstance(
+     *         new \Darling\PHPJsonStorageUtilities\classes\collections\JsonStorageDirectoryPathCollection()
+     *     );
+     * }
+     *
+     * ```
+     *
+     */
+    abstract protected function setUp(): void;
+
+    /**
+     * Return the JsonStorageDirectoryPathCollection implementation instance to test.
+     *
+     * @return JsonStorageDirectoryPathCollection
+     *
+     */
+    protected function jsonStorageDirectoryPathCollectionTestInstance(): JsonStorageDirectoryPathCollection
+    {
+        return $this->jsonStorageDirectoryPathCollection;
+    }
+
+    /**
+     * Set the JsonStorageDirectoryPathCollection implementation instance to test.
+     *
+     * @param JsonStorageDirectoryPathCollection $jsonStorageDirectoryPathCollectionTestInstance
+     *                              An instance of an
+     *                              implementation of
+     *                              the JsonStorageDirectoryPathCollection
+     *                              interface to test.
+     *
+     * @return void
+     *
+     */
+    protected function setJsonStorageDirectoryPathCollectionTestInstance(
+        JsonStorageDirectoryPathCollection $jsonStorageDirectoryPathCollectionTestInstance
+    ): void
+    {
+        $this->jsonStorageDirectoryPathCollection = $jsonStorageDirectoryPathCollectionTestInstance;
+    }
+
+    /**
+     * Set the array of JsonStorageDirectoryPath instances that is
+     * expected to be returned by the JsonStorageDirectoryPathCollection
+     * instance being tested's collection() method.
+     *
+     * @param array<int, JsonStorageDirectoryPath> $collection
+     *
+     * @return void
+     *
+     */
+    protected function setExpectedCollection(array $collection): void
+    {
+        $this->expectedCollection = $collection;
+    }
+
+    /**
+     * Return the array of JsonStorageDirectoryPath instances that is
+     * expected to be returned by the JsonStorageDirectoryPathCollection
+     * instance being tested's collection() method.
+     *
+     * @return array<int, JsonStorageDirectoryPath>
+     *
+     */
+    protected function expectedCollection(): array
+    {
+        return $this->expectedCollection;
+    }
+
+    /**
+     * Test collection() returns the expected array of
+     * JsonStorageDirectoryPath instances.
+     *
+     * @return void
+     *
+     * @covers JsonStorageDirectoryPathCollection->collection()
+     *
+     */
+    public function test_collection_returns_the_expected_array_of_JsonStorageDirectoryPath_instances(): void
+    {
+        $this->assertEquals(
+            $this->expectedCollection(),
+            $this->jsonStorageDirectoryPathCollectionTestInstance()->collection(),
+            $this->testFailedMessage(
+                $this->jsonStorageDirectoryPathCollectionTestInstance(),
+                'collection',
+                'return the expected array of JsonStorageDirectoryPath instances'
+            ),
+        );
+    }
+}
+

--- a/tests/interfaces/collections/JsonStorageDirectoryPathCollectionTestTrait.php
+++ b/tests/interfaces/collections/JsonStorageDirectoryPathCollectionTestTrait.php
@@ -6,8 +6,9 @@ use \Darling\PHPJsonStorageUtilities\interfaces\collections\JsonStorageDirectory
 use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\paths\JsonStorageDirectoryPath;
 
 /**
- * The JsonStorageDirectoryPathCollectionTestTrait defines common tests for
- * implementations of the JsonStorageDirectoryPathCollection interface.
+ * The JsonStorageDirectoryPathCollectionTestTrait defines common
+ * tests for implementations of the JsonStorageDirectoryPathCollection
+ * interface.
  *
  * @see JsonStorageDirectoryPathCollection
  *
@@ -24,15 +25,30 @@ trait JsonStorageDirectoryPathCollectionTestTrait
     protected JsonStorageDirectoryPathCollection $jsonStorageDirectoryPathCollection;
 
     /**
-     * @var array<int, JsonStorageDirectoryPath>
+     * @var array<int, JsonStorageDirectoryPath> The array of
+     *                                           JsonStorageDirectoryPath
+     *                                           instances that is
+     *                                           expected to be
+     *                                           returned by the
+     *                                           JsonStorageDirectoryPathCollection
+     *                                           instance being
+     *                                           tested's collection()
+     *                                           method.
      */
     private array $expectedCollection = [];
 
     /**
-     * Set up an instance of a JsonStorageDirectoryPathCollection implementation to test.
+     * Set up an instance of a JsonStorageDirectoryPathCollection
+     * implementation to test.
      *
-     * This method must also set the JsonStorageDirectoryPathCollection implementation instance
-     * to be tested via the setJsonStorageDirectoryPathCollectionTestInstance() method.
+     * This method must set the JsonStorageDirectoryPathCollection
+     * implementation instance to be tested via the
+     * setJsonStorageDirectoryPathCollectionTestInstance() method.
+     *
+     * This method must also set the array of JsonStorageDirectoryPath
+     * instances that is expected to be returned by the
+     * JsonStorageDirectoryPathCollection instance being tested's
+     * collection() method via the setExpectedCollection() method.
      *
      * This method may also be used to perform any additional setup
      * required by the implementation being tested.
@@ -42,10 +58,31 @@ trait JsonStorageDirectoryPathCollectionTestTrait
      * @example
      *
      * ```
-     * protected function setUp(): void
+     * public function setUp(): void
      * {
+     *     $this->setExpectedCollection(
+     *         [
+     *             new JsonStorageDirectoryPath(
+     *                 new Name(new Text($this->randomChars())),
+     *             ),
+     *             new JsonStorageDirectoryPath(
+     *                 new Name(new Text($this->randomChars())),
+     *             ),
+     *             new JsonStorageDirectoryPath(
+     *                 new Name(new Text($this->randomChars())),
+     *             ),
+     *             new JsonStorageDirectoryPath(
+     *                 new Name(new Text($this->randomChars())),
+     *             ),
+     *             new JsonStorageDirectoryPath(
+     *                 new Name(new Text($this->randomChars())),
+     *             ),
+     *         ]
+     *     );
      *     $this->setJsonStorageDirectoryPathCollectionTestInstance(
-     *         new \Darling\PHPJsonStorageUtilities\classes\collections\JsonStorageDirectoryPathCollection()
+     *         new JsonStorageDirectoryPathCollection(
+     *             ...$this->expectedCollection(),
+     *         )
      *     );
      * }
      *
@@ -55,7 +92,8 @@ trait JsonStorageDirectoryPathCollectionTestTrait
     abstract protected function setUp(): void;
 
     /**
-     * Return the JsonStorageDirectoryPathCollection implementation instance to test.
+     * Return the JsonStorageDirectoryPathCollection implementation
+     * instance to test.
      *
      * @return JsonStorageDirectoryPathCollection
      *
@@ -66,13 +104,15 @@ trait JsonStorageDirectoryPathCollectionTestTrait
     }
 
     /**
-     * Set the JsonStorageDirectoryPathCollection implementation instance to test.
+     * Set the JsonStorageDirectoryPathCollection implementation
+     * instance to test.
      *
      * @param JsonStorageDirectoryPathCollection $jsonStorageDirectoryPathCollectionTestInstance
-     *                              An instance of an
-     *                              implementation of
-     *                              the JsonStorageDirectoryPathCollection
-     *                              interface to test.
+     *                                           An instance of an
+     *                                           implementation of
+     *                                           the
+     *                                           JsonStorageDirectoryPathCollection
+     *                                           interface to test.
      *
      * @return void
      *
@@ -133,5 +173,6 @@ trait JsonStorageDirectoryPathCollectionTestTrait
             ),
         );
     }
+
 }
 

--- a/tests/interfaces/collections/LocationCollectionTestTrait.php
+++ b/tests/interfaces/collections/LocationCollectionTestTrait.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace Darling\PHPJsonStorageUtilities\tests\interfaces\collections;
+
+use \Darling\PHPJsonStorageUtilities\interfaces\collections\LocationCollection;
+use \Darling\PHPJsonStorageUtilities\interfaces\named\identifiers\Location;
+
+/**
+ * The LocationCollectionTestTrait defines common tests for
+ * implementations of the LocationCollection interface.
+ *
+ * @see LocationCollection
+ *
+ */
+trait LocationCollectionTestTrait
+{
+
+    /**
+     * @var LocationCollection $locationCollection
+     *                              An instance of a
+     *                              LocationCollection
+     *                              implementation to test.
+     */
+    protected LocationCollection $locationCollection;
+
+    /**
+     * @var array<int, Location> The array of Location instances that
+     *                           is expected to be returned by the
+     *                           LocationCollection instance being
+     *                           tested's collection() method.
+     */
+    private array $expectedCollection = [];
+
+    /**
+     * Set up an instance of a LocationCollection implementation to
+     * test.
+     *
+     * This method must set the LocationCollection
+     * implementation instance to be tested via the
+     * setLocationCollectionTestInstance() method.
+     *
+     * This method must also set the array of Location
+     * instances that is expected to be returned by the
+     * LocationCollection instance being tested's
+     * collection() method via the setExpectedCollection() method.
+     *
+     * This method may also be used to perform any additional setup
+     * required by the implementation being tested.
+     *
+     * @return void
+     *
+     * @example
+     *
+     * ```
+     * public function setUp(): void
+     * {
+     *     $this->setExpectedCollection(
+     *         [
+     *             new Location(
+     *                 new Name(new Text($this->randomChars())),
+     *             ),
+     *             new Location(
+     *                 new Name(new Text($this->randomChars())),
+     *             ),
+     *             new Location(
+     *                 new Name(new Text($this->randomChars())),
+     *             ),
+     *             new Location(
+     *                 new Name(new Text($this->randomChars())),
+     *             ),
+     *             new Location(
+     *                 new Name(new Text($this->randomChars())),
+     *             ),
+     *         ]
+     *     );
+     *     $this->setLocationCollectionTestInstance(
+     *         new LocationCollection(
+     *             ...$this->expectedCollection(),
+     *         )
+     *     );
+     * }
+     *
+     * ```
+     *
+     */
+    abstract protected function setUp(): void;
+
+    /**
+     * Return the LocationCollection implementation instance to test.
+     *
+     * @return LocationCollection
+     *
+     */
+    protected function locationCollectionTestInstance(): LocationCollection
+    {
+        return $this->locationCollection;
+    }
+
+    /**
+     * Set the LocationCollection implementation instance to test.
+     *
+     * @param LocationCollection $locationCollectionTestInstance
+     *                                           An instance of an
+     *                                           implementation of
+     *                                           the
+     *                                           LocationCollection
+     *                                           interface to test.
+     *
+     * @return void
+     *
+     */
+    protected function setLocationCollectionTestInstance(
+        LocationCollection $locationCollectionTestInstance
+    ): void
+    {
+        $this->locationCollection = $locationCollectionTestInstance;
+    }
+
+    /**
+     * Set the array of Location instances that is expected to be
+     * returned by the LocationCollection instance being tested's
+     * collection() method.
+     *
+     * @param array<int, Location> $collection
+     *
+     * @return void
+     *
+     */
+    protected function setExpectedCollection(array $collection): void
+    {
+        $this->expectedCollection = $collection;
+    }
+
+    /**
+     * Return the array of Location instances that is expected to be
+     * returned by the LocationCollection instance being tested's
+     * collection() method.
+     *
+     * @return array<int, Location>
+     *
+     */
+    protected function expectedCollection(): array
+    {
+        return $this->expectedCollection;
+    }
+
+    /**
+     * Test collection() returns the expected array of Location
+     * instances.
+     *
+     * @return void
+     *
+     * @covers LocationCollection->collection()
+     *
+     */
+    public function test_collection_returns_the_expected_array_of_Location_instances(): void
+    {
+        $this->assertEquals(
+            $this->expectedCollection(),
+            $this->locationCollectionTestInstance()->collection(),
+            $this->testFailedMessage(
+                $this->locationCollectionTestInstance(),
+                'collection',
+                'return the expected array of Location instances'
+            ),
+        );
+    }
+
+}
+

--- a/tests/interfaces/collections/NameCollectionTestTrait.php
+++ b/tests/interfaces/collections/NameCollectionTestTrait.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Darling\PHPJsonStorageUtilities\tests\interfaces\collections;
+
+use \Darling\PHPJsonStorageUtilities\interfaces\collections\NameCollection;
+use \Darling\PHPTextTypes\classes\strings\Name;
+
+/**
+ * The NameCollectionTestTrait defines common tests for
+ * implementations of the NameCollection interface.
+ *
+ * @see NameCollection
+ *
+ */
+trait NameCollectionTestTrait
+{
+
+    /**
+     * @var NameCollection $nameCollection An instance of a
+     *                                     NameCollection
+     *                                     implementation to test.
+     */
+    protected NameCollection $nameCollection;
+
+    /**
+     * @var array<int, Name> The array of Name instances that is
+     *                       expected to be returned by the
+     *                       NameCollection instance being tested's
+     *                       collection() method.
+     */
+    private array $expectedCollection = [];
+
+    /**
+     * Set up an instance of a NameCollection implementation to test.
+     *
+     * This method must set the NameCollection implementation
+     * instance to be tested via the setNameCollectionTestInstance()
+     * method.
+     *
+     * This method must also set the array of Name instances that is
+     * expected to be returned by the NameCollection instance being
+     * tested's collection() method via the setExpectedCollection()
+     * method.
+     *
+     * This method may also be used to perform any additional setup
+     * required by the implementation being tested.
+     *
+     * @return void
+     *
+     * @example
+     *
+     * ```
+     * public function setUp(): void
+     * {
+     *     $this->setExpectedCollection(
+     *         [
+     *             new Name(new Name(new Text($this->randomChars()))),
+     *             new Name(new Name(new Text($this->randomChars()))),
+     *             new Name(new Name(new Text($this->randomChars()))),
+     *             new Name(new Name(new Text($this->randomChars()))),
+     *             new Name(new Name(new Text($this->randomChars()))),
+     *         ]
+     *     );
+     *     $this->setNameCollectionTestInstance(
+     *         new NameCollection(
+     *             ...$this->expectedCollection(),
+     *         )
+     *     );
+     * }
+     *
+     * ```
+     *
+     */
+    abstract protected function setUp(): void;
+
+    /**
+     * Return the NameCollection implementation instance to test.
+     *
+     * @return NameCollection
+     *
+     */
+    protected function nameCollectionTestInstance(): NameCollection
+    {
+        return $this->nameCollection;
+    }
+
+    /**
+     * Set the NameCollection implementation instance to test.
+     *
+     * @param NameCollection $nameCollectionTestInstance An instance
+     *                                                  of an
+     *                                                  implementation
+     *                                                  of the
+     *                                                  NameCollection
+     *                                                  interface to
+     *                                                  test.
+     *
+     * @return void
+     *
+     */
+    protected function setNameCollectionTestInstance(
+        NameCollection $nameCollectionTestInstance
+    ): void
+    {
+        $this->nameCollection = $nameCollectionTestInstance;
+    }
+
+    /**
+     * Set the array of Name instances that is expected to be
+     * returned by the NameCollection instance being tested's
+     * collection() method.
+     *
+     * @param array<int, Name> $collection
+     *
+     * @return void
+     *
+     */
+    protected function setExpectedCollection(array $collection): void
+    {
+        $this->expectedCollection = $collection;
+    }
+
+    /**
+     * Return the array of Name instances that is expected to be
+     * returned by the NameCollection instance being tested's
+     * collection() method.
+     *
+     * @return array<int, Name>
+     *
+     */
+    protected function expectedCollection(): array
+    {
+        return $this->expectedCollection;
+    }
+
+    /**
+     * Test collection() returns the expected array of Name instances.
+     *
+     * @return void
+     *
+     * @covers NameCollection->collection()
+     *
+     */
+    public function test_collection_returns_the_expected_array_of_Name_instances(): void
+    {
+        $this->assertEquals(
+            $this->expectedCollection(),
+            $this->nameCollectionTestInstance()->collection(),
+            $this->testFailedMessage(
+                $this->nameCollectionTestInstance(),
+                'collection',
+                'return the expected array of Name instances'
+            ),
+        );
+    }
+
+}
+

--- a/tests/interfaces/collections/OwnerCollectionTestTrait.php
+++ b/tests/interfaces/collections/OwnerCollectionTestTrait.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace Darling\PHPJsonStorageUtilities\tests\interfaces\collections;
+
+use \Darling\PHPJsonStorageUtilities\interfaces\collections\OwnerCollection;
+use \Darling\PHPJsonStorageUtilities\interfaces\named\identifiers\Owner;
+
+/**
+ * The OwnerCollectionTestTrait defines common tests for
+ * implementations of the OwnerCollection interface.
+ *
+ * @see OwnerCollection
+ *
+ */
+trait OwnerCollectionTestTrait
+{
+
+    /**
+     * @var OwnerCollection $ownerCollection An instance of a
+     *                                       OwnerCollection
+     *                                       implementation
+     *                                       to test.
+     */
+    protected OwnerCollection $ownerCollection;
+
+    /**
+     * @var array<int, Owner> The array of Owner instances that is
+     *                        expected to be returned by the
+     *                        OwnerCollection instance being
+     *                        tested's collection() method.
+     */
+    private array $expectedCollection = [];
+
+    /**
+     * Set up an instance of a OwnerCollection implementation to test.
+     *
+     * This method must set the OwnerCollection implementation
+     * instance to be tested via the setOwnerCollectionTestInstance()
+     * method.
+     *
+     * This method must also set the array of Owner instances that is
+     * expected to be returned by the OwnerCollection instance being
+     * tested's collection() method via the setExpectedCollection()
+     * method.
+     *
+     * This method may also be used to perform any additional setup
+     * required by the implementation being tested.
+     *
+     * @return void
+     *
+     * @example
+     *
+     * ```
+     * public function setUp(): void
+     * {
+     *     $this->setExpectedCollection(
+     *         [
+     *             new Owner(
+     *                 new Name(new Text($this->randomChars())),
+     *             ),
+     *             new Owner(
+     *                 new Name(new Text($this->randomChars())),
+     *             ),
+     *             new Owner(
+     *                 new Name(new Text($this->randomChars())),
+     *             ),
+     *             new Owner(
+     *                 new Name(new Text($this->randomChars())),
+     *             ),
+     *             new Owner(
+     *                 new Name(new Text($this->randomChars())),
+     *             ),
+     *         ]
+     *     );
+     *     $this->setOwnerCollectionTestInstance(
+     *         new OwnerCollection(
+     *             ...$this->expectedCollection(),
+     *         )
+     *     );
+     * }
+     *
+     * ```
+     *
+     */
+    abstract protected function setUp(): void;
+
+    /**
+     * Return the OwnerCollection implementation instance to test.
+     *
+     * @return OwnerCollection
+     *
+     */
+    protected function ownerCollectionTestInstance(): OwnerCollection
+    {
+        return $this->ownerCollection;
+    }
+
+    /**
+     * Set the OwnerCollection implementation instance to test.
+     *
+     * @param OwnerCollection $ownerCollectionTestInstance An instance
+     *                                                     of an
+     *                                                     implementation
+     *                                                     of the
+     *                                                     OwnerCollection
+     *                                                     interface
+     *                                                     to test.
+     *
+     * @return void
+     *
+     */
+    protected function setOwnerCollectionTestInstance(
+        OwnerCollection $ownerCollectionTestInstance
+    ): void
+    {
+        $this->ownerCollection = $ownerCollectionTestInstance;
+    }
+
+    /**
+     * Set the array of Owner instances that is expected to be
+     * returned by the OwnerCollection instance being tested's
+     * collection() method.
+     *
+     * @param array<int, Owner> $collection
+     *
+     * @return void
+     *
+     */
+    protected function setExpectedCollection(array $collection): void
+    {
+        $this->expectedCollection = $collection;
+    }
+
+    /**
+     * Return the array of Owner instances that is expected to be
+     * returned by the OwnerCollection instance being tested's
+     * collection() method.
+     *
+     * @return array<int, Owner>
+     *
+     */
+    protected function expectedCollection(): array
+    {
+        return $this->expectedCollection;
+    }
+
+    /**
+     * Test collection() returns the expected array of Owner
+     * instances.
+     *
+     * @return void
+     *
+     * @covers OwnerCollection->collection()
+     *
+     */
+    public function test_collection_returns_the_expected_array_of_Owner_instances(): void
+    {
+        $this->assertEquals(
+            $this->expectedCollection(),
+            $this->ownerCollectionTestInstance()->collection(),
+            $this->testFailedMessage(
+                $this->ownerCollectionTestInstance(),
+                'collection',
+                'return the expected array of Owner instances'
+            ),
+        );
+    }
+
+}
+

--- a/tests/interfaces/filesystem/storage/queries/JsonStorageQueryTestTrait.php
+++ b/tests/interfaces/filesystem/storage/queries/JsonStorageQueryTestTrait.php
@@ -42,6 +42,21 @@ trait JsonStorageQueryTestTrait
 
 
     /**
+     * @var array<int, Container> The array of
+     *                                           Container
+     *                                           instances that is
+     *                                           expected to be
+     *                                           returned by the
+     *                                           JsonStorageQuery
+     *                                           being tested's
+     *                                           containers()
+     *                                           method.
+     */
+    private array $expectedContainers;
+
+
+
+    /**
      * @var array<int, Location> The array of
      *                                           Location
      *                                           instances that is
@@ -176,6 +191,59 @@ trait JsonStorageQueryTestTrait
             ),
         );
     }
+
+
+    /**
+     * Set the array of Container instances
+     * that is expected to be returned by the JsonStorageQuery
+     * instance being tested's containers() method.
+     *
+     * @param array<int, Container> $containers
+     *
+     */
+    protected function setExpectedContainers(
+        array $containers
+    ): void
+    {
+        $this->expectedContainers = $containers;
+    }
+
+    /**
+     * Return the array of Container instances
+     * that is expected to be returned by the JsonStorageQuery
+     * instance being tested's containers() method.
+     *
+     * @return array<int, Container>
+     *
+     */
+    protected function expectedContainers(): array
+    {
+        return $this->expectedContainers;
+    }
+
+    /**
+     * Test that the containers() method returns the
+     * expected array of Container instances.
+     *
+     * @return void
+     *
+     * @covers JsonStorageQuery->containers()
+     *
+     */
+    public function test_containers_returns_an_array_of_the_expected_Container_instances(): void
+    {
+        $this->assertEquals(
+            $this->expectedContainers(),
+            $this->jsonStorageQueryTestInstance()->containers(),
+            $this->testFailedMessage(
+                $this->jsonStorageQueryTestInstance(),
+                'containers',
+                'return an array of the expected ' .
+                'Container instances'
+            ),
+        );
+    }
+
 
 
     /**

--- a/tests/interfaces/filesystem/storage/queries/JsonStorageQueryTestTrait.php
+++ b/tests/interfaces/filesystem/storage/queries/JsonStorageQueryTestTrait.php
@@ -7,6 +7,7 @@ use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\paths\JsonFilePath;
 use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\storage\queries\JsonStorageQuery;
 use \Darling\PHPJsonStorageUtilities\classes\named\identifiers\Location;
 use \Darling\PHPJsonStorageUtilities\classes\named\identifiers\Owner;
+use \Darling\PHPTextTypes\classes\strings\Name;
 use \Darling\PHPJsonStorageUtilities\classes\named\identifiers\Container;
 
 /**
@@ -39,6 +40,21 @@ trait JsonStorageQueryTestTrait
      *                                           method.
      */
     private array $expectedJsonStorageDirectoryPaths;
+
+
+    /**
+     * @var array<int, Name> The array of
+     *                                           Name
+     *                                           instances that is
+     *                                           expected to be
+     *                                           returned by the
+     *                                           JsonStorageQuery
+     *                                           being tested's
+     *                                           names()
+     *                                           method.
+     */
+    private array $expectedNames;
+
 
 
     /**
@@ -206,6 +222,59 @@ trait JsonStorageQueryTestTrait
             ),
         );
     }
+
+
+    /**
+     * Set the array of Name instances
+     * that is expected to be returned by the JsonStorageQuery
+     * instance being tested's names() method.
+     *
+     * @param array<int, Name> $names
+     *
+     */
+    protected function setExpectedNames(
+        array $names
+    ): void
+    {
+        $this->expectedNames = $names;
+    }
+
+    /**
+     * Return the array of Name instances
+     * that is expected to be returned by the JsonStorageQuery
+     * instance being tested's names() method.
+     *
+     * @return array<int, Name>
+     *
+     */
+    protected function expectedNames(): array
+    {
+        return $this->expectedNames;
+    }
+
+    /**
+     * Test that the names() method returns the
+     * expected array of Name instances.
+     *
+     * @return void
+     *
+     * @covers JsonStorageQuery->names()
+     *
+     */
+    public function test_names_returns_an_array_of_the_expected_Name_instances(): void
+    {
+        $this->assertEquals(
+            $this->expectedNames(),
+            $this->jsonStorageQueryTestInstance()->names(),
+            $this->testFailedMessage(
+                $this->jsonStorageQueryTestInstance(),
+                'names',
+                'return an array of the expected ' .
+                'Name instances'
+            ),
+        );
+    }
+
 
 
     /**

--- a/tests/interfaces/filesystem/storage/queries/JsonStorageQueryTestTrait.php
+++ b/tests/interfaces/filesystem/storage/queries/JsonStorageQueryTestTrait.php
@@ -43,6 +43,21 @@ trait JsonStorageQueryTestTrait
 
 
     /**
+     * @var array<int, Id> The array of
+     *                                           Id
+     *                                           instances that is
+     *                                           expected to be
+     *                                           returned by the
+     *                                           JsonStorageQuery
+     *                                           being tested's
+     *                                           ids()
+     *                                           method.
+     */
+    private array $expectedIds;
+
+
+
+    /**
      * @var array<int, Name> The array of
      *                                           Name
      *                                           instances that is
@@ -222,6 +237,59 @@ trait JsonStorageQueryTestTrait
             ),
         );
     }
+
+
+    /**
+     * Set the array of Id instances
+     * that is expected to be returned by the JsonStorageQuery
+     * instance being tested's ids() method.
+     *
+     * @param array<int, Id> $ids
+     *
+     */
+    protected function setExpectedIds(
+        array $ids
+    ): void
+    {
+        $this->expectedIds = $ids;
+    }
+
+    /**
+     * Return the array of Id instances
+     * that is expected to be returned by the JsonStorageQuery
+     * instance being tested's ids() method.
+     *
+     * @return array<int, Id>
+     *
+     */
+    protected function expectedIds(): array
+    {
+        return $this->expectedIds;
+    }
+
+    /**
+     * Test that the ids() method returns the
+     * expected array of Id instances.
+     *
+     * @return void
+     *
+     * @covers JsonStorageQuery->ids()
+     *
+     */
+    public function test_ids_returns_an_array_of_the_expected_Id_instances(): void
+    {
+        $this->assertEquals(
+            $this->expectedIds(),
+            $this->jsonStorageQueryTestInstance()->ids(),
+            $this->testFailedMessage(
+                $this->jsonStorageQueryTestInstance(),
+                'ids',
+                'return an array of the expected ' .
+                'Id instances'
+            ),
+        );
+    }
+
 
 
     /**
@@ -489,17 +557,4 @@ trait JsonStorageQueryTestTrait
 
 
 }
-
-# JsonFilePaths
-# jsonFilePaths
-# Locations
-# locations
-# Containers
-# containers
-# Owners
-# owners
-# Names
-# names
-# Ids
-# ids
 

--- a/tests/interfaces/filesystem/storage/queries/JsonStorageQueryTestTrait.php
+++ b/tests/interfaces/filesystem/storage/queries/JsonStorageQueryTestTrait.php
@@ -2,8 +2,8 @@
 
 namespace Darling\PHPJsonStorageUtilities\tests\interfaces\filesystem\storage\queries;
 
-use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\storage\queries\JsonStorageQuery;
 use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\paths\JsonStorageDirectoryPath;
+use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\storage\queries\JsonStorageQuery;
 
 /**
  * The JsonStorageQueryTestTrait defines common tests for
@@ -100,7 +100,9 @@ trait JsonStorageQueryTestTrait
      * @param array<int, JsonStorageDirectoryPath> $jsonStorageDirectoryPaths
      *
      */
-    protected function setExpectedJsonStorageDirectoryPaths(array $jsonStorageDirectoryPaths): void
+    protected function setExpectedJsonStorageDirectoryPaths(
+        array $jsonStorageDirectoryPaths
+    ): void
     {
         $this->expectedJsonStorageDirectoryPaths = $jsonStorageDirectoryPaths;
     }

--- a/tests/interfaces/filesystem/storage/queries/JsonStorageQueryTestTrait.php
+++ b/tests/interfaces/filesystem/storage/queries/JsonStorageQueryTestTrait.php
@@ -5,6 +5,9 @@ namespace Darling\PHPJsonStorageUtilities\tests\interfaces\filesystem\storage\qu
 use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\paths\JsonStorageDirectoryPath;
 use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\paths\JsonFilePath;
 use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\storage\queries\JsonStorageQuery;
+use \Darling\PHPJsonStorageUtilities\classes\named\identifiers\Location;
+use \Darling\PHPJsonStorageUtilities\classes\named\identifiers\Owner;
+use \Darling\PHPJsonStorageUtilities\classes\named\identifiers\Container;
 
 /**
  * The JsonStorageQueryTestTrait defines common tests for
@@ -36,6 +39,21 @@ trait JsonStorageQueryTestTrait
      *                                           method.
      */
     private array $expectedJsonStorageDirectoryPaths;
+
+
+    /**
+     * @var array<int, Location> The array of
+     *                                           Location
+     *                                           instances that is
+     *                                           expected to be
+     *                                           returned by the
+     *                                           JsonStorageQuery
+     *                                           being tested's
+     *                                           locations()
+     *                                           method.
+     */
+    private array $expectedLocations;
+
 
 
     /**
@@ -158,6 +176,59 @@ trait JsonStorageQueryTestTrait
             ),
         );
     }
+
+
+    /**
+     * Set the array of Location instances
+     * that is expected to be returned by the JsonStorageQuery
+     * instance being tested's locations() method.
+     *
+     * @param array<int, Location> $locations
+     *
+     */
+    protected function setExpectedLocations(
+        array $locations
+    ): void
+    {
+        $this->expectedLocations = $locations;
+    }
+
+    /**
+     * Return the array of Location instances
+     * that is expected to be returned by the JsonStorageQuery
+     * instance being tested's locations() method.
+     *
+     * @return array<int, Location>
+     *
+     */
+    protected function expectedLocations(): array
+    {
+        return $this->expectedLocations;
+    }
+
+    /**
+     * Test that the locations() method returns the
+     * expected array of Location instances.
+     *
+     * @return void
+     *
+     * @covers JsonStorageQuery->locations()
+     *
+     */
+    public function test_locations_returns_an_array_of_the_expected_Location_instances(): void
+    {
+        $this->assertEquals(
+            $this->expectedLocations(),
+            $this->jsonStorageQueryTestInstance()->locations(),
+            $this->testFailedMessage(
+                $this->jsonStorageQueryTestInstance(),
+                'locations',
+                'return an array of the expected ' .
+                'Location instances'
+            ),
+        );
+    }
+
 
 
     /**

--- a/tests/interfaces/filesystem/storage/queries/JsonStorageQueryTestTrait.php
+++ b/tests/interfaces/filesystem/storage/queries/JsonStorageQueryTestTrait.php
@@ -42,6 +42,21 @@ trait JsonStorageQueryTestTrait
 
 
     /**
+     * @var array<int, Owner> The array of
+     *                                           Owner
+     *                                           instances that is
+     *                                           expected to be
+     *                                           returned by the
+     *                                           JsonStorageQuery
+     *                                           being tested's
+     *                                           owners()
+     *                                           method.
+     */
+    private array $expectedOwners;
+
+
+
+    /**
      * @var array<int, Container> The array of
      *                                           Container
      *                                           instances that is
@@ -191,6 +206,59 @@ trait JsonStorageQueryTestTrait
             ),
         );
     }
+
+
+    /**
+     * Set the array of Owner instances
+     * that is expected to be returned by the JsonStorageQuery
+     * instance being tested's owners() method.
+     *
+     * @param array<int, Owner> $owners
+     *
+     */
+    protected function setExpectedOwners(
+        array $owners
+    ): void
+    {
+        $this->expectedOwners = $owners;
+    }
+
+    /**
+     * Return the array of Owner instances
+     * that is expected to be returned by the JsonStorageQuery
+     * instance being tested's owners() method.
+     *
+     * @return array<int, Owner>
+     *
+     */
+    protected function expectedOwners(): array
+    {
+        return $this->expectedOwners;
+    }
+
+    /**
+     * Test that the owners() method returns the
+     * expected array of Owner instances.
+     *
+     * @return void
+     *
+     * @covers JsonStorageQuery->owners()
+     *
+     */
+    public function test_owners_returns_an_array_of_the_expected_Owner_instances(): void
+    {
+        $this->assertEquals(
+            $this->expectedOwners(),
+            $this->jsonStorageQueryTestInstance()->owners(),
+            $this->testFailedMessage(
+                $this->jsonStorageQueryTestInstance(),
+                'owners',
+                'return an array of the expected ' .
+                'Owner instances'
+            ),
+        );
+    }
+
 
 
     /**

--- a/tests/interfaces/filesystem/storage/queries/JsonStorageQueryTestTrait.php
+++ b/tests/interfaces/filesystem/storage/queries/JsonStorageQueryTestTrait.php
@@ -5,10 +5,11 @@ namespace Darling\PHPJsonStorageUtilities\tests\interfaces\filesystem\storage\qu
 use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\paths\JsonStorageDirectoryPath;
 use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\paths\JsonFilePath;
 use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\storage\queries\JsonStorageQuery;
-use \Darling\PHPJsonStorageUtilities\classes\named\identifiers\Location;
-use \Darling\PHPJsonStorageUtilities\classes\named\identifiers\Owner;
-use \Darling\PHPTextTypes\classes\strings\Name;
-use \Darling\PHPJsonStorageUtilities\classes\named\identifiers\Container;
+use \Darling\PHPJsonStorageUtilities\interfaces\named\identifiers\Location;
+use \Darling\PHPJsonStorageUtilities\interfaces\named\identifiers\Owner;
+use \Darling\PHPTextTypes\interfaces\strings\Name;
+use \Darling\PHPTextTypes\interfaces\strings\Id;
+use \Darling\PHPJsonStorageUtilities\interfaces\named\identifiers\Container;
 
 /**
  * The JsonStorageQueryTestTrait defines common tests for

--- a/tests/interfaces/filesystem/storage/queries/JsonStorageQueryTestTrait.php
+++ b/tests/interfaces/filesystem/storage/queries/JsonStorageQueryTestTrait.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Darling\PHPJsonStorageUtilities\tests\interfaces\filesystem\storage\queries;
+
+use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\storage\queries\JsonStorageQuery;
+use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\paths\JsonStorageDirectoryPath;
+
+/**
+ * The JsonStorageQueryTestTrait defines common tests for
+ * implementations of the JsonStorageQuery interface.
+ *
+ * @see JsonStorageQuery
+ *
+ */
+trait JsonStorageQueryTestTrait
+{
+
+    /**
+     * @var JsonStorageQuery $jsonStorageQuery An instance of a
+     *                                         JsonStorageQuery
+     *                                         implementation to
+     *                                         test.
+     */
+    protected JsonStorageQuery $jsonStorageQuery;
+
+    /**
+     * @var array<int, JsonStorageDirectoryPath> The array of
+     *                                           JsonStorageDirectoryPath
+     *                                           instances that is
+     *                                           expected to be
+     *                                           returned by the
+     *                                           JsonStorageQuery
+     *                                           being tested's
+     *                                           jsonStorageDirectoryPaths()
+     *                                           method.
+     */
+    private array $expectedJsonStorageDirectoryPaths;
+
+    /**
+     * Set up an instance of a JsonStorageQuery implementation to test.
+     *
+     * This method must also set the JsonStorageQuery implementation instance
+     * to be tested via the setJsonStorageQueryTestInstance() method.
+     *
+     * This method may also be used to perform any additional setup
+     * required by the implementation being tested.
+     *
+     * @return void
+     *
+     * @example
+     *
+     * ```
+     * protected function setUp(): void
+     * {
+     *     $this->setJsonStorageQueryTestInstance(
+     *         new \Darling\PHPJsonStorageUtilities\classes\filesystem\storage\queries\JsonStorageQuery()
+     *     );
+     * }
+     *
+     * ```
+     *
+     */
+    abstract protected function setUp(): void;
+
+    /**
+     * Return the JsonStorageQuery implementation instance to test.
+     *
+     * @return JsonStorageQuery
+     *
+     */
+    protected function jsonStorageQueryTestInstance(): JsonStorageQuery
+    {
+        return $this->jsonStorageQuery;
+    }
+
+    /**
+     * Set the JsonStorageQuery implementation instance to test.
+     *
+     * @param JsonStorageQuery $jsonStorageQueryTestInstance
+     *                              An instance of an
+     *                              implementation of
+     *                              the JsonStorageQuery
+     *                              interface to test.
+     *
+     * @return void
+     *
+     */
+    protected function setJsonStorageQueryTestInstance(
+        JsonStorageQuery $jsonStorageQueryTestInstance
+    ): void
+    {
+        $this->jsonStorageQuery = $jsonStorageQueryTestInstance;
+    }
+
+    /**
+     * Set the array of JsonStorageDirectoryPath instances
+     * that is expected to be returned by the JsonStorageQuery
+     * instance being tested's jsonStorageDirectoryPaths() method.
+     *
+     * @param array<int, JsonStorageDirectoryPath> $jsonStorageDirectoryPaths
+     *
+     */
+    protected function setExpectedJsonStorageDirectoryPaths(array $jsonStorageDirectoryPaths): void
+    {
+        $this->expectedJsonStorageDirectoryPaths = $jsonStorageDirectoryPaths;
+    }
+
+    /**
+     * Return the array of JsonStorageDirectoryPath instances
+     * that is expected to be returned by the JsonStorageQuery
+     * instance being tested's jsonStorageDirectoryPaths() method.
+     *
+     * @return array<int, JsonStorageDirectoryPath>
+     *
+     */
+    protected function expectedJsonStorageDirectoryPaths(): array
+    {
+        return $this->expectedJsonStorageDirectoryPaths;
+    }
+
+    /**
+     * Test that the jsonStorageDirectoryPaths() method returns the
+     * expected array of JsonStorageDirectoryPath instances.
+     *
+     * @return void
+     *
+     * @covers JsonStorageQuery->jsonStorageDirectoryPaths()
+     *
+     */
+    public function test_jsonStorageDirectoryPaths_returns_an_array_of_the_expected_JsonStorageDirectoryPath_instances(): void
+    {
+        $this->assertEquals(
+            $this->expectedJsonStorageDirectoryPaths(),
+            $this->jsonStorageQueryTestInstance()->jsonStorageDirectoryPaths(),
+            $this->testFailedMessage(
+                $this->jsonStorageQueryTestInstance(),
+                'jsonStorageDirectoryPaths',
+                'return an array of the expected ' .
+                'JsonStorageDirectoryPath instances'
+            ),
+        );
+    }
+
+}
+

--- a/tests/interfaces/filesystem/storage/queries/JsonStorageQueryTestTrait.php
+++ b/tests/interfaces/filesystem/storage/queries/JsonStorageQueryTestTrait.php
@@ -3,6 +3,7 @@
 namespace Darling\PHPJsonStorageUtilities\tests\interfaces\filesystem\storage\queries;
 
 use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\paths\JsonStorageDirectoryPath;
+use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\paths\JsonFilePath;
 use \Darling\PHPJsonStorageUtilities\interfaces\filesystem\storage\queries\JsonStorageQuery;
 
 /**
@@ -35,6 +36,21 @@ trait JsonStorageQueryTestTrait
      *                                           method.
      */
     private array $expectedJsonStorageDirectoryPaths;
+
+
+    /**
+     * @var array<int, JsonFilePath> The array of
+     *                                           JsonFilePath
+     *                                           instances that is
+     *                                           expected to be
+     *                                           returned by the
+     *                                           JsonStorageQuery
+     *                                           being tested's
+     *                                           jsonFilePaths()
+     *                                           method.
+     */
+    private array $expectedJsonFilePaths;
+
 
     /**
      * Set up an instance of a JsonStorageQuery implementation to test.
@@ -143,5 +159,71 @@ trait JsonStorageQueryTestTrait
         );
     }
 
+
+    /**
+     * Set the array of JsonFilePath instances
+     * that is expected to be returned by the JsonStorageQuery
+     * instance being tested's jsonFilePaths() method.
+     *
+     * @param array<int, JsonFilePath> $jsonFilePaths
+     *
+     */
+    protected function setExpectedJsonFilePaths(
+        array $jsonFilePaths
+    ): void
+    {
+        $this->expectedJsonFilePaths = $jsonFilePaths;
+    }
+
+    /**
+     * Return the array of JsonFilePath instances
+     * that is expected to be returned by the JsonStorageQuery
+     * instance being tested's jsonFilePaths() method.
+     *
+     * @return array<int, JsonFilePath>
+     *
+     */
+    protected function expectedJsonFilePaths(): array
+    {
+        return $this->expectedJsonFilePaths;
+    }
+
+    /**
+     * Test that the jsonFilePaths() method returns the
+     * expected array of JsonFilePath instances.
+     *
+     * @return void
+     *
+     * @covers JsonStorageQuery->jsonFilePaths()
+     *
+     */
+    public function test_jsonFilePaths_returns_an_array_of_the_expected_JsonFilePath_instances(): void
+    {
+        $this->assertEquals(
+            $this->expectedJsonFilePaths(),
+            $this->jsonStorageQueryTestInstance()->jsonFilePaths(),
+            $this->testFailedMessage(
+                $this->jsonStorageQueryTestInstance(),
+                'jsonFilePaths',
+                'return an array of the expected ' .
+                'JsonFilePath instances'
+            ),
+        );
+    }
+
+
 }
+
+# JsonFilePaths
+# jsonFilePaths
+# Locations
+# locations
+# Containers
+# containers
+# Owners
+# owners
+# Names
+# names
+# Ids
+# ids
 


### PR DESCRIPTION
Resolved most of issue #19. Still need to refactor `\Darling\PHPJsonUtilities\classes\filesystem\queries\JsonStorageQuery` to use the new `Collections` instead of `arrays`.

    Implemented the following `Collection` interfaces:

    ```
    \Darling\PHPJsonUtilities\interfaces\collections\ContainerCollection
    \Darling\PHPJsonUtilities\interfaces\collections\IdCollection
    \Darling\PHPJsonUtilities\interfaces\collections\JsonFilePathCollection
    \Darling\PHPJsonUtilities\interfaces\collections\JsonStorageDirectoryPathCollection
    \Darling\PHPJsonUtilities\interfaces\collections\LocationCollection
    \Darling\PHPJsonUtilities\interfaces\collections\NameCollection
    \Darling\PHPJsonUtilities\interfaces\collections\OwnerCollection

    ```